### PR TITLE
Implement refresh token cookie handling

### DIFF
--- a/src/main/java/com/example/TaskFlow/Constants/Constants.java
+++ b/src/main/java/com/example/TaskFlow/Constants/Constants.java
@@ -12,6 +12,7 @@ public class Constants {
     public static final String ROLES = "roles";
     public static final String TYPE = "type";
     public static final String BEARER_PREFIX = "Bearer ";
+    public static final String REFRESH_TOKEN_COOKIE = "refreshToken";
 
     public static ResponseEntity<Map<String,String>> invalid(String reason){
         String message = "invalid " + reason;

--- a/src/main/java/com/example/TaskFlow/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/example/TaskFlow/jwt/JwtAuthFilter.java
@@ -40,6 +40,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         String uri = req.getRequestURI();
         return uri.equals("/auth/login") ||
                 uri.equals("/auth/identify") ||
+                uri.equals("/auth/refresh") ||
                 uri.equals("/auth/register") ||
                 uri.startsWith("/v3/api-docs") ||
                 uri.startsWith("/swagger-ui");

--- a/src/main/java/com/example/TaskFlow/service/JwtService.java
+++ b/src/main/java/com/example/TaskFlow/service/JwtService.java
@@ -70,7 +70,7 @@ public class JwtService {
                 .subject(username)
                 .issuer(issuer)
                 .issuedAt(Date.from(now))
-                .issuedAt(Date.from(expire))
+                .expiration(Date.from(expire))
                 .claim(Constants.TYPE,Constants.REFRESH_TOKEN_CLAIM)
                 .claim(Constants.ROLES,roles)
                 .signWith(secretKey,Jwts.SIG.HS256)
@@ -105,11 +105,11 @@ public class JwtService {
     }
     //Returns whether the Token is a Refresh Token or not
     public boolean isRefreshToken(Claims claims){
-        return Constants.REFRESH_TOKEN_CLAIM.equals(claims.get(Constants.REFRESH_TOKEN_CLAIM));
+        return Constants.REFRESH_TOKEN_CLAIM.equals(claims.get(Constants.TYPE));
     }
     //Returns whether the Token is a Access Token or not
     public boolean isActiveToken(Claims claims){
-        return Constants.ACCESS_TOKEN_CLAIM.equals(claims.get(Constants.ACCESS_TOKEN_CLAIM));
+        return Constants.ACCESS_TOKEN_CLAIM.equals(claims.get(Constants.TYPE));
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary
- set the login endpoint to send the refresh token as an HTTP-only cookie and only return the access token in the response body
- add a refresh endpoint that validates the refresh token from the cookie and issues a new access token without rotating the refresh token
- correct refresh-token parsing helpers and allow the refresh route to bypass JWT filtering

## Testing
- mvn test *(fails: Non-resolvable parent POM due to network connectivity to Spring snapshot repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c9bc11cdf0832a9845fcf896c70987