### PR TITLE
Add core project entities, DTOs, and persistence tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,7 @@
 ## Build and Run via Executable JAR
 1. Package the service with `./mvnw clean package`.
 2. Run the generated artifact using `java -jar target/TaskFlow-0.0.1-SNAPSHOT.jar`.
+
+## Entity Relationship Diagram
+
+The core relationships between users, teams, projects, and tasks are documented in [docs/er-diagram.mmd](docs/er-diagram.mmd). The file uses Mermaid syntax and can be rendered by any Mermaid-compatible tool or IDE plugin.

--- a/docs/er-diagram.mmd
+++ b/docs/er-diagram.mmd
@@ -1,0 +1,72 @@
+---
+title: TaskFlow Core ER Diagram
+---
+erDiagram
+    USER ||--o{ TEAM_MEMBERS : participates_in
+    TEAM ||--o{ TEAM_MEMBERS : includes
+    TEAM ||--o{ PROJECT : owns
+    PROJECT ||--o{ TASK : contains
+    TASK ||--o{ COMMENT : receives
+    TASK ||--o{ ATTACHMENT : stores
+    USER ||--o{ COMMENT : authors
+    USER ||--o{ ATTACHMENT : uploads
+    USER ||--o{ TASK : assigned_to
+
+    USER {
+        LONG id PK
+        STRING email
+        STRING username
+        STRING first_name
+        STRING last_name
+    }
+
+    TEAM {
+        LONG id PK
+        STRING name
+        STRING description
+        INSTANT created_at
+        INSTANT updated_at
+    }
+
+    PROJECT {
+        LONG id PK
+        LONG team_id FK
+        STRING name
+        STRING description
+        INTEGER board_order
+        INSTANT created_at
+        INSTANT updated_at
+    }
+
+    TASK {
+        LONG id PK
+        LONG project_id FK
+        STRING title
+        STRING description
+        STRING status
+        STRING priority
+        DATE due_date
+        INTEGER column_position
+        INTEGER swimlane_position
+        LONG assignee_id FK
+        LONG assigned_by_id FK
+        INSTANT assigned_at
+    }
+
+    COMMENT {
+        LONG id PK
+        LONG task_id FK
+        LONG author_id FK
+        STRING body
+        INSTANT created_at
+    }
+
+    ATTACHMENT {
+        LONG id PK
+        LONG task_id FK
+        LONG uploaded_by_id FK
+        STRING file_name
+        STRING storage_url
+        LONG file_size_bytes
+        INSTANT created_at
+    }

--- a/pom.xml
+++ b/pom.xml
@@ -73,13 +73,18 @@
 		</dependency>
 
 		<!-- Validation API -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<!-- Reactor Test for testing reactive streams -->
-		<dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <!-- Reactor Test for testing reactive streams -->
+                <dependency>
 			<groupId>io.projectreactor</groupId>
 			<artifactId>reactor-test</artifactId>
 			<scope>test</scope>

--- a/src/main/java/com/example/TaskFlow/dto/request/AttachmentRequestDTO.java
+++ b/src/main/java/com/example/TaskFlow/dto/request/AttachmentRequestDTO.java
@@ -1,0 +1,18 @@
+package com.example.TaskFlow.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class AttachmentRequestDTO {
+
+    private Long taskId;
+    private Long uploadedById;
+    private String fileName;
+    private String fileType;
+    private String storageUrl;
+    private Long fileSizeBytes;
+}

--- a/src/main/java/com/example/TaskFlow/dto/request/CommentRequestDTO.java
+++ b/src/main/java/com/example/TaskFlow/dto/request/CommentRequestDTO.java
@@ -1,0 +1,15 @@
+package com.example.TaskFlow.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class CommentRequestDTO {
+
+    private Long taskId;
+    private Long authorId;
+    private String body;
+}

--- a/src/main/java/com/example/TaskFlow/dto/request/ProjectRequestDTO.java
+++ b/src/main/java/com/example/TaskFlow/dto/request/ProjectRequestDTO.java
@@ -1,0 +1,16 @@
+package com.example.TaskFlow.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ProjectRequestDTO {
+
+    private Long teamId;
+    private String name;
+    private String description;
+    private Integer boardOrder;
+}

--- a/src/main/java/com/example/TaskFlow/dto/request/TaskAssignmentRequestDTO.java
+++ b/src/main/java/com/example/TaskFlow/dto/request/TaskAssignmentRequestDTO.java
@@ -1,0 +1,15 @@
+package com.example.TaskFlow.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class TaskAssignmentRequestDTO {
+
+    private Long assigneeId;
+    private Long assignedById;
+    private String notes;
+}

--- a/src/main/java/com/example/TaskFlow/dto/request/TaskRequestDTO.java
+++ b/src/main/java/com/example/TaskFlow/dto/request/TaskRequestDTO.java
@@ -1,0 +1,25 @@
+package com.example.TaskFlow.dto.request;
+
+import com.example.TaskFlow.model.enums.TaskPriority;
+import com.example.TaskFlow.model.enums.TaskStatus;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class TaskRequestDTO {
+
+    private Long projectId;
+    private String title;
+    private String description;
+    private TaskStatus status;
+    private TaskPriority priority;
+    private LocalDate dueDate;
+    private Integer columnPosition;
+    private Integer swimlanePosition;
+    private TaskAssignmentRequestDTO assignment;
+}

--- a/src/main/java/com/example/TaskFlow/dto/request/TeamRequestDTO.java
+++ b/src/main/java/com/example/TaskFlow/dto/request/TeamRequestDTO.java
@@ -1,0 +1,17 @@
+package com.example.TaskFlow.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.Set;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class TeamRequestDTO {
+
+    private String name;
+    private String description;
+    private Set<Long> memberIds;
+}

--- a/src/main/java/com/example/TaskFlow/dto/response/AttachmentResponseDTO.java
+++ b/src/main/java/com/example/TaskFlow/dto/response/AttachmentResponseDTO.java
@@ -1,0 +1,27 @@
+package com.example.TaskFlow.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AttachmentResponseDTO {
+
+    private Long id;
+    private Long taskId;
+    private Long uploadedById;
+    private String fileName;
+    private String fileType;
+    private String storageUrl;
+    private Long fileSizeBytes;
+    private Instant createdAt;
+    private Instant updatedAt;
+}

--- a/src/main/java/com/example/TaskFlow/dto/response/CommentResponseDTO.java
+++ b/src/main/java/com/example/TaskFlow/dto/response/CommentResponseDTO.java
@@ -1,0 +1,24 @@
+package com.example.TaskFlow.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CommentResponseDTO {
+
+    private Long id;
+    private Long taskId;
+    private Long authorId;
+    private String body;
+    private Instant createdAt;
+    private Instant updatedAt;
+}

--- a/src/main/java/com/example/TaskFlow/dto/response/ProjectResponseDTO.java
+++ b/src/main/java/com/example/TaskFlow/dto/response/ProjectResponseDTO.java
@@ -1,0 +1,27 @@
+package com.example.TaskFlow.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProjectResponseDTO {
+
+    private Long id;
+    private Long teamId;
+    private String name;
+    private String description;
+    private Integer boardOrder;
+    private Instant createdAt;
+    private Instant updatedAt;
+    private List<TaskSummaryDTO> tasks;
+}

--- a/src/main/java/com/example/TaskFlow/dto/response/ProjectSummaryDTO.java
+++ b/src/main/java/com/example/TaskFlow/dto/response/ProjectSummaryDTO.java
@@ -1,0 +1,20 @@
+package com.example.TaskFlow.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProjectSummaryDTO {
+
+    private Long id;
+    private String name;
+    private Integer boardOrder;
+    private Long teamId;
+}

--- a/src/main/java/com/example/TaskFlow/dto/response/TaskAssignmentResponseDTO.java
+++ b/src/main/java/com/example/TaskFlow/dto/response/TaskAssignmentResponseDTO.java
@@ -1,0 +1,22 @@
+package com.example.TaskFlow.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TaskAssignmentResponseDTO {
+
+    private Long assigneeId;
+    private Long assignedById;
+    private Instant assignedAt;
+    private String notes;
+}

--- a/src/main/java/com/example/TaskFlow/dto/response/TaskResponseDTO.java
+++ b/src/main/java/com/example/TaskFlow/dto/response/TaskResponseDTO.java
@@ -1,0 +1,36 @@
+package com.example.TaskFlow.dto.response;
+
+import com.example.TaskFlow.model.enums.TaskPriority;
+import com.example.TaskFlow.model.enums.TaskStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TaskResponseDTO {
+
+    private Long id;
+    private Long projectId;
+    private String title;
+    private String description;
+    private TaskStatus status;
+    private TaskPriority priority;
+    private LocalDate dueDate;
+    private Integer columnPosition;
+    private Integer swimlanePosition;
+    private TaskAssignmentResponseDTO assignment;
+    private Instant createdAt;
+    private Instant updatedAt;
+    private List<CommentResponseDTO> comments;
+    private List<AttachmentResponseDTO> attachments;
+}

--- a/src/main/java/com/example/TaskFlow/dto/response/TaskSummaryDTO.java
+++ b/src/main/java/com/example/TaskFlow/dto/response/TaskSummaryDTO.java
@@ -1,0 +1,24 @@
+package com.example.TaskFlow.dto.response;
+
+import com.example.TaskFlow.model.enums.TaskPriority;
+import com.example.TaskFlow.model.enums.TaskStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TaskSummaryDTO {
+
+    private Long id;
+    private String title;
+    private TaskStatus status;
+    private TaskPriority priority;
+    private Integer columnPosition;
+    private Integer swimlanePosition;
+}

--- a/src/main/java/com/example/TaskFlow/dto/response/TeamResponseDTO.java
+++ b/src/main/java/com/example/TaskFlow/dto/response/TeamResponseDTO.java
@@ -1,0 +1,27 @@
+package com.example.TaskFlow.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TeamResponseDTO {
+
+    private Long id;
+    private String name;
+    private String description;
+    private Instant createdAt;
+    private Instant updatedAt;
+    private Set<Long> memberIds;
+    private List<ProjectSummaryDTO> projects;
+}

--- a/src/main/java/com/example/TaskFlow/model/Attachment.java
+++ b/src/main/java/com/example/TaskFlow/model/Attachment.java
@@ -1,0 +1,55 @@
+package com.example.TaskFlow.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "attachments", schema = "taskflow_auth")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString(exclude = {"task", "uploadedBy"})
+public class Attachment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "task_id", nullable = false)
+    private Task task;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "uploaded_by_id")
+    private User uploadedBy;
+
+    @Column(nullable = false, length = 255)
+    private String fileName;
+
+    @Column(length = 100)
+    private String fileType;
+
+    @Column(nullable = false, length = 512)
+    private String storageUrl;
+
+    @Column(name = "file_size_bytes")
+    private Long fileSizeBytes;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    private Instant updatedAt;
+}

--- a/src/main/java/com/example/TaskFlow/model/Comment.java
+++ b/src/main/java/com/example/TaskFlow/model/Comment.java
@@ -1,0 +1,46 @@
+package com.example.TaskFlow.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "comments", schema = "taskflow_auth")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString(exclude = {"task", "author"})
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "task_id", nullable = false)
+    private Task task;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id", nullable = false)
+    private User author;
+
+    @Column(nullable = false, length = 2048)
+    private String body;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    private Instant updatedAt;
+}

--- a/src/main/java/com/example/TaskFlow/model/Project.java
+++ b/src/main/java/com/example/TaskFlow/model/Project.java
@@ -1,0 +1,65 @@
+package com.example.TaskFlow.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "projects", schema = "taskflow_auth")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString(exclude = {"team", "tasks"})
+public class Project {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 150)
+    private String name;
+
+    @Column(length = 1024)
+    private String description;
+
+    @Column(name = "board_order")
+    private Integer boardOrder;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id", nullable = false)
+    private Team team;
+
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("columnPosition ASC, id ASC")
+    @Builder.Default
+    private List<Task> tasks = new ArrayList<>();
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    private Instant updatedAt;
+
+    public void addTask(Task task) {
+        tasks.add(task);
+        task.setProject(this);
+    }
+
+    public void removeTask(Task task) {
+        tasks.remove(task);
+        task.setProject(null);
+    }
+}

--- a/src/main/java/com/example/TaskFlow/model/Task.java
+++ b/src/main/java/com/example/TaskFlow/model/Task.java
@@ -1,0 +1,127 @@
+package com.example.TaskFlow.model;
+
+import com.example.TaskFlow.model.enums.TaskPriority;
+import com.example.TaskFlow.model.enums.TaskStatus;
+import com.example.TaskFlow.model.value.AssignmentMetadata;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "tasks", schema = "taskflow_auth")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString(exclude = {"project", "comments", "attachments"})
+public class Task {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(length = 2048)
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 32)
+    private TaskStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 32)
+    private TaskPriority priority;
+
+    @Column(name = "due_date")
+    private LocalDate dueDate;
+
+    @Column(name = "column_position")
+    private Integer columnPosition;
+
+    @Column(name = "swimlane_position")
+    private Integer swimlanePosition;
+
+    @Embedded
+    private AssignmentMetadata assignment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+    @OneToMany(mappedBy = "task", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("createdAt ASC")
+    @Builder.Default
+    private List<Comment> comments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "task", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("createdAt ASC")
+    @Builder.Default
+    private List<Attachment> attachments = new ArrayList<>();
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    private Instant updatedAt;
+
+    @PrePersist
+    public void prePersist() {
+        if (status == null) {
+            status = TaskStatus.BACKLOG;
+        }
+        if (priority == null) {
+            priority = TaskPriority.MEDIUM;
+        }
+        if (columnPosition == null) {
+            columnPosition = 0;
+        }
+        if (swimlanePosition == null) {
+            swimlanePosition = 0;
+        }
+    }
+
+    public void addComment(Comment comment) {
+        comments.add(comment);
+        comment.setTask(this);
+    }
+
+    public void removeComment(Comment comment) {
+        comments.remove(comment);
+        comment.setTask(null);
+    }
+
+    public void addAttachment(Attachment attachment) {
+        attachments.add(attachment);
+        attachment.setTask(this);
+    }
+
+    public void removeAttachment(Attachment attachment) {
+        attachments.remove(attachment);
+        attachment.setTask(null);
+    }
+
+    public void assignTo(User assignee, User assignedBy, Instant assignedAt, String notes) {
+        if (assignment == null) {
+            assignment = new AssignmentMetadata();
+        }
+        assignment.setAssignee(assignee);
+        assignment.setAssignedBy(assignedBy);
+        assignment.setAssignedAt(assignedAt);
+        assignment.setNotes(notes);
+    }
+}

--- a/src/main/java/com/example/TaskFlow/model/Team.java
+++ b/src/main/java/com/example/TaskFlow/model/Team.java
@@ -1,0 +1,80 @@
+package com.example.TaskFlow.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Entity
+@Table(name = "teams", schema = "taskflow_auth")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString(exclude = {"members", "projects"})
+public class Team {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 150)
+    private String name;
+
+    @Column(length = 1024)
+    private String description;
+
+    @ManyToMany
+    @JoinTable(
+            name = "team_members",
+            schema = "taskflow_auth",
+            joinColumns = @JoinColumn(name = "team_id", foreignKey = @ForeignKey(name = "fk_team_members_team")),
+            inverseJoinColumns = @JoinColumn(name = "user_id", foreignKey = @ForeignKey(name = "fk_team_members_user"))
+    )
+    @Builder.Default
+    private Set<User> members = new HashSet<>();
+
+    @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("name ASC")
+    @Builder.Default
+    private List<Project> projects = new ArrayList<>();
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    private Instant updatedAt;
+
+    public void addMember(User user) {
+        members.add(user);
+        user.getTeams().add(this);
+    }
+
+    public void removeMember(User user) {
+        members.remove(user);
+        user.getTeams().remove(this);
+    }
+
+    public void addProject(Project project) {
+        projects.add(project);
+        project.setTeam(this);
+    }
+
+    public void removeProject(Project project) {
+        projects.remove(project);
+        project.setTeam(null);
+    }
+}

--- a/src/main/java/com/example/TaskFlow/model/User.java
+++ b/src/main/java/com/example/TaskFlow/model/User.java
@@ -8,6 +8,9 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
+import java.util.HashSet;
+import java.util.Set;
+
 // This class represents a User entity in the database
 // It is mapped to the "users" table in the "taskflow_auth" schema
 // It has unique constraints on the email and username columns
@@ -30,7 +33,7 @@ import lombok.ToString;
 @Getter // Lombok annotation to generate getters for all fields
 @Setter // Lombok annotation to generate setters for all fields
 @EqualsAndHashCode // Lombok annotation to generate equals and hashCode methods
-@ToString // Lombok annotation to generate toString method
+@ToString(exclude = {"teams"}) // Lombok annotation to generate toString method
 
 public class User {
     @Id //Primary key for the Table
@@ -78,5 +81,8 @@ public class User {
 
     @Column(name = "failed_login_attempts")
     private Integer failedLoginAttempts;
+
+    @ManyToMany(mappedBy = "members")
+    private Set<Team> teams = new HashSet<>();
 
 }

--- a/src/main/java/com/example/TaskFlow/model/enums/TaskPriority.java
+++ b/src/main/java/com/example/TaskFlow/model/enums/TaskPriority.java
@@ -1,0 +1,11 @@
+package com.example.TaskFlow.model.enums;
+
+/**
+ * Represents the priority of a task.
+ */
+public enum TaskPriority {
+    LOW,
+    MEDIUM,
+    HIGH,
+    CRITICAL
+}

--- a/src/main/java/com/example/TaskFlow/model/enums/TaskStatus.java
+++ b/src/main/java/com/example/TaskFlow/model/enums/TaskStatus.java
@@ -1,0 +1,22 @@
+package com.example.TaskFlow.model.enums;
+
+/**
+ * Represents the lifecycle for a task in the TaskFlow board.
+ */
+public enum TaskStatus {
+    BACKLOG,
+    TODO,
+    IN_PROGRESS,
+    IN_REVIEW,
+    BLOCKED,
+    DONE;
+
+    /**
+     * Indicates whether the status represents work that has been completed.
+     *
+     * @return true if the status is a terminal state.
+     */
+    public boolean isTerminal() {
+        return this == DONE;
+    }
+}

--- a/src/main/java/com/example/TaskFlow/model/value/AssignmentMetadata.java
+++ b/src/main/java/com/example/TaskFlow/model/value/AssignmentMetadata.java
@@ -1,0 +1,41 @@
+package com.example.TaskFlow.model.value;
+
+import com.example.TaskFlow.model.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+
+/**
+ * Stores information about how a task is assigned.
+ */
+@Embeddable
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AssignmentMetadata {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "assignee_id")
+    private User assignee;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "assigned_by_id")
+    private User assignedBy;
+
+    @Column(name = "assigned_at")
+    private Instant assignedAt;
+
+    @Column(name = "assignment_notes", length = 1024)
+    private String notes;
+}

--- a/src/main/java/com/example/TaskFlow/repo/AttachmentRepository.java
+++ b/src/main/java/com/example/TaskFlow/repo/AttachmentRepository.java
@@ -1,0 +1,13 @@
+package com.example.TaskFlow.repo;
+
+import com.example.TaskFlow.model.Attachment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface AttachmentRepository extends JpaRepository<Attachment, Long> {
+
+    List<Attachment> findByTaskId(Long taskId);
+}

--- a/src/main/java/com/example/TaskFlow/repo/CommentRepository.java
+++ b/src/main/java/com/example/TaskFlow/repo/CommentRepository.java
@@ -1,0 +1,13 @@
+package com.example.TaskFlow.repo;
+
+import com.example.TaskFlow.model.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    List<Comment> findByTaskId(Long taskId);
+}

--- a/src/main/java/com/example/TaskFlow/repo/ProjectRepository.java
+++ b/src/main/java/com/example/TaskFlow/repo/ProjectRepository.java
@@ -1,0 +1,16 @@
+package com.example.TaskFlow.repo;
+
+import com.example.TaskFlow.model.Project;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+
+    List<Project> findByTeamId(Long teamId);
+
+    Optional<Project> findByTeamIdAndNameIgnoreCase(Long teamId, String name);
+}

--- a/src/main/java/com/example/TaskFlow/repo/TaskRepository.java
+++ b/src/main/java/com/example/TaskFlow/repo/TaskRepository.java
@@ -1,0 +1,20 @@
+package com.example.TaskFlow.repo;
+
+import com.example.TaskFlow.model.Task;
+import com.example.TaskFlow.model.enums.TaskStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TaskRepository extends JpaRepository<Task, Long> {
+
+    List<Task> findByProjectId(Long projectId);
+
+    List<Task> findByProjectTeamId(Long teamId);
+
+    List<Task> findByAssignment_Assignee_Id(Long userId);
+
+    List<Task> findByStatusOrderByColumnPositionAsc(TaskStatus status);
+}

--- a/src/main/java/com/example/TaskFlow/repo/TeamRepository.java
+++ b/src/main/java/com/example/TaskFlow/repo/TeamRepository.java
@@ -1,0 +1,16 @@
+package com.example.TaskFlow.repo;
+
+import com.example.TaskFlow.model.Team;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface TeamRepository extends JpaRepository<Team, Long> {
+
+    Optional<Team> findByNameIgnoreCase(String name);
+
+    List<Team> findByMembers_Id(Long userId);
+}

--- a/src/test/java/com/example/TaskFlow/repo/TeamProjectTaskRepositoryTest.java
+++ b/src/test/java/com/example/TaskFlow/repo/TeamProjectTaskRepositoryTest.java
@@ -1,0 +1,146 @@
+package com.example.TaskFlow.repo;
+
+import com.example.TaskFlow.model.Attachment;
+import com.example.TaskFlow.model.Comment;
+import com.example.TaskFlow.model.Project;
+import com.example.TaskFlow.model.Task;
+import com.example.TaskFlow.model.Team;
+import com.example.TaskFlow.model.User;
+import com.example.TaskFlow.model.enums.TaskPriority;
+import com.example.TaskFlow.model.enums.TaskStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class TeamProjectTaskRepositoryTest {
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private TaskRepository taskRepository;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private AttachmentRepository attachmentRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void shouldPersistTeamProjectAndTaskGraph() {
+        User owner = createUser("owner", "owner@example.com");
+        User contributor = createUser("contributor", "contributor@example.com");
+        owner = userRepository.save(owner);
+        contributor = userRepository.save(contributor);
+
+        Team team = Team.builder()
+                .name("Engineering")
+                .description("Builds the platform")
+                .build();
+        team.addMember(owner);
+        team.addMember(contributor);
+
+        Project project = Project.builder()
+                .name("Platform")
+                .description("Core services")
+                .boardOrder(1)
+                .build();
+        team.addProject(project);
+
+        Task task = Task.builder()
+                .title("Bootstrap project")
+                .description("Set up CI/CD and skeleton modules")
+                .status(TaskStatus.IN_PROGRESS)
+                .priority(TaskPriority.HIGH)
+                .dueDate(LocalDate.now().plusDays(7))
+                .columnPosition(2)
+                .swimlanePosition(1)
+                .build();
+        task.assignTo(contributor, owner, Instant.now(), "Initial assignment");
+        project.addTask(task);
+
+        Comment comment = Comment.builder()
+                .author(owner)
+                .body("Kick-off meeting held")
+                .build();
+        task.addComment(comment);
+
+        Attachment attachment = Attachment.builder()
+                .fileName("roadmap.pdf")
+                .fileType("application/pdf")
+                .storageUrl("https://storage/taskflow/roadmap.pdf")
+                .fileSizeBytes(2048L)
+                .uploadedBy(contributor)
+                .build();
+        task.addAttachment(attachment);
+
+        Team savedTeam = teamRepository.saveAndFlush(team);
+
+        List<Team> teamsForOwner = teamRepository.findByMembers_Id(owner.getId());
+        assertThat(teamsForOwner).hasSize(1);
+        Team persistedTeam = teamsForOwner.get(0);
+        assertThat(persistedTeam.getProjects()).hasSize(1);
+        Project persistedProject = persistedTeam.getProjects().get(0);
+        assertThat(persistedProject.getTasks()).hasSize(1);
+        Task persistedTask = persistedProject.getTasks().get(0);
+        assertThat(persistedTask.getComments()).hasSize(1);
+        assertThat(persistedTask.getAttachments()).hasSize(1);
+        assertThat(persistedTask.getAssignment().getAssignee().getId()).isEqualTo(contributor.getId());
+
+        List<Project> projectsByTeam = projectRepository.findByTeamId(savedTeam.getId());
+        assertThat(projectsByTeam).extracting(Project::getName).containsExactly("Platform");
+
+        List<Task> tasksByProject = taskRepository.findByProjectId(persistedProject.getId());
+        assertThat(tasksByProject).hasSize(1);
+        assertThat(tasksByProject.get(0).getTitle()).isEqualTo("Bootstrap project");
+
+        List<Task> tasksByTeam = taskRepository.findByProjectTeamId(savedTeam.getId());
+        assertThat(tasksByTeam).hasSize(1);
+
+        List<Task> tasksByAssignee = taskRepository.findByAssignment_Assignee_Id(contributor.getId());
+        assertThat(tasksByAssignee).hasSize(1);
+        assertThat(tasksByAssignee.get(0).getAssignment().getNotes()).isEqualTo("Initial assignment");
+
+        assertThat(taskRepository.findByStatusOrderByColumnPositionAsc(TaskStatus.IN_PROGRESS))
+                .extracting(Task::getColumnPosition)
+                .containsExactly(2);
+
+        assertThat(commentRepository.findByTaskId(persistedTask.getId()))
+                .hasSize(1)
+                .extracting(Comment::getBody)
+                .containsExactly("Kick-off meeting held");
+
+        assertThat(attachmentRepository.findByTaskId(persistedTask.getId()))
+                .hasSize(1)
+                .extracting(Attachment::getFileName)
+                .containsExactly("roadmap.pdf");
+    }
+
+    private User createUser(String username, String email) {
+        User user = new User();
+        user.setUsername(username);
+        user.setEmail(email);
+        user.setPasswordHash("password");
+        user.setFirstname("Test");
+        user.setLastname("User");
+        user.setMiddlename(null);
+        user.setIsActive(true);
+        user.setIsLocked(false);
+        user.setIsDeleted(false);
+        user.setFailedLoginAttempts(0);
+        return user;
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,8 @@
+spring.datasource.url=jdbc:h2:mem:taskflow;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false
+spring.datasource.username=sa
+spring.datasource.password=
+spring.datasource.driver-class-name=org.h2.Driver
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.show-sql=false
+spring.sql.init.mode=always

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -1,0 +1,1 @@
+CREATE SCHEMA IF NOT EXISTS taskflow_auth;


### PR DESCRIPTION
## Summary
- introduce JPA entities for teams, projects, tasks, comments, attachments and their supporting enums/value objects
- add request/response DTOs and repositories to keep domain access behind Spring Data abstractions
- document relationships with an ER diagram and cover persistence flows with repository tests

## Testing
- mvn test *(fails: unable to resolve Spring Boot parent POM because Maven Central is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d32149b1e8832ab91f712f48930ef9