### PR TITLE
Add task management entities and persistence tests

### DIFF
--- a/docs/er-diagram.mmd
+++ b/docs/er-diagram.mmd
@@ -1,0 +1,82 @@
+erDiagram
+    USER ||--o{ TEAM_MEMBERS : "joins"
+    TEAM ||--o{ TEAM_MEMBERS : "has"
+    TEAM ||--o{ PROJECT : "owns"
+    PROJECT ||--o{ TASK : "contains"
+    TASK ||--o{ TASK_COMMENTS : "receives"
+    USER ||--o{ TASK_COMMENTS : "authors"
+    TASK ||--o{ TASK_ATTACHMENTS : "stores"
+    USER ||--o{ TASK_ASSIGNMENT : "assigned"
+
+    USER {
+        bigint id PK
+        varchar email
+        varchar username
+        varchar first_name
+        varchar last_name
+    }
+
+    TEAM {
+        bigint id PK
+        varchar name
+        varchar description
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    PROJECT {
+        bigint id PK
+        varchar name
+        varchar description
+        date start_date
+        date due_date
+        bigint team_id FK
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    TASK {
+        bigint id PK
+        varchar title
+        text description
+        varchar status
+        varchar priority
+        date due_date
+        integer sort_order
+        bigint project_id FK
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    TASK_ASSIGNMENT {
+        bigint task_id FK
+        bigint assignee_id FK
+        bigint delegate_id FK
+        timestamp assigned_at
+        timestamp acknowledged_at
+        timestamp completed_at
+    }
+
+    TASK_COMMENTS {
+        bigint id PK
+        bigint task_id FK
+        bigint author_id FK
+        text content
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    TASK_ATTACHMENTS {
+        bigint id PK
+        bigint task_id FK
+        varchar file_name
+        varchar storage_url
+        varchar content_type
+        bigint file_size
+        timestamp uploaded_at
+    }
+
+    TEAM_MEMBERS {
+        bigint team_id FK
+        bigint user_id FK
+    }

--- a/pom.xml
+++ b/pom.xml
@@ -73,11 +73,16 @@
 		</dependency>
 
 		<!-- Validation API -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <scope>test</scope>
+                </dependency>
 		<!-- Reactor Test for testing reactive streams -->
 		<dependency>
 			<groupId>io.projectreactor</groupId>

--- a/src/main/java/com/example/TaskFlow/dto/request/AttachmentRequestDTO.java
+++ b/src/main/java/com/example/TaskFlow/dto/request/AttachmentRequestDTO.java
@@ -1,0 +1,27 @@
+package com.example.TaskFlow.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class AttachmentRequestDTO {
+
+    @NotNull
+    private Long taskId;
+
+    @NotBlank
+    @Size(max = 255)
+    private String fileName;
+
+    @Size(max = 100)
+    private String contentType;
+
+    @NotBlank
+    @Size(max = 512)
+    private String storageUrl;
+
+    @NotNull
+    private Long fileSize;
+}

--- a/src/main/java/com/example/TaskFlow/dto/request/CommentRequestDTO.java
+++ b/src/main/java/com/example/TaskFlow/dto/request/CommentRequestDTO.java
@@ -1,0 +1,20 @@
+package com.example.TaskFlow.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class CommentRequestDTO {
+
+    @NotNull
+    private Long taskId;
+
+    @NotNull
+    private Long authorId;
+
+    @NotBlank
+    @Size(max = 2000)
+    private String content;
+}

--- a/src/main/java/com/example/TaskFlow/dto/request/ProjectRequestDTO.java
+++ b/src/main/java/com/example/TaskFlow/dto/request/ProjectRequestDTO.java
@@ -1,0 +1,26 @@
+package com.example.TaskFlow.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+public class ProjectRequestDTO {
+
+    @NotNull
+    private Long teamId;
+
+    @NotBlank
+    @Size(max = 128)
+    private String name;
+
+    @Size(max = 1024)
+    private String description;
+
+    private LocalDate startDate;
+
+    private LocalDate dueDate;
+}

--- a/src/main/java/com/example/TaskFlow/dto/request/TaskRequestDTO.java
+++ b/src/main/java/com/example/TaskFlow/dto/request/TaskRequestDTO.java
@@ -1,0 +1,43 @@
+package com.example.TaskFlow.dto.request;
+
+import com.example.TaskFlow.model.enums.TaskPriority;
+import com.example.TaskFlow.model.enums.TaskStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+import java.time.Instant;
+import java.time.LocalDate;
+
+@Data
+public class TaskRequestDTO {
+
+    @NotNull
+    private Long projectId;
+
+    @NotBlank
+    @Size(max = 200)
+    private String title;
+
+    @Size(max = 4000)
+    private String description;
+
+    private TaskStatus status;
+
+    private TaskPriority priority;
+
+    private Long assigneeId;
+
+    private Long delegateId;
+
+    private Instant assignedAt;
+
+    private Instant acknowledgedAt;
+
+    private Instant completedAt;
+
+    private LocalDate dueDate;
+
+    private Integer sortOrder;
+}

--- a/src/main/java/com/example/TaskFlow/dto/request/TeamRequestDTO.java
+++ b/src/main/java/com/example/TaskFlow/dto/request/TeamRequestDTO.java
@@ -1,0 +1,20 @@
+package com.example.TaskFlow.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+import java.util.Set;
+
+@Data
+public class TeamRequestDTO {
+
+    @NotBlank
+    @Size(max = 128)
+    private String name;
+
+    @Size(max = 512)
+    private String description;
+
+    private Set<Long> memberIds;
+}

--- a/src/main/java/com/example/TaskFlow/dto/response/AttachmentResponseDTO.java
+++ b/src/main/java/com/example/TaskFlow/dto/response/AttachmentResponseDTO.java
@@ -1,0 +1,18 @@
+package com.example.TaskFlow.dto.response;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.time.Instant;
+
+@Value
+@Builder
+public class AttachmentResponseDTO {
+    Long id;
+    Long taskId;
+    String fileName;
+    String contentType;
+    String storageUrl;
+    Long fileSize;
+    Instant uploadedAt;
+}

--- a/src/main/java/com/example/TaskFlow/dto/response/CommentResponseDTO.java
+++ b/src/main/java/com/example/TaskFlow/dto/response/CommentResponseDTO.java
@@ -1,0 +1,17 @@
+package com.example.TaskFlow.dto.response;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.time.Instant;
+
+@Value
+@Builder
+public class CommentResponseDTO {
+    Long id;
+    Long taskId;
+    Long authorId;
+    String content;
+    Instant createdAt;
+    Instant updatedAt;
+}

--- a/src/main/java/com/example/TaskFlow/dto/response/ProjectResponseDTO.java
+++ b/src/main/java/com/example/TaskFlow/dto/response/ProjectResponseDTO.java
@@ -1,0 +1,22 @@
+package com.example.TaskFlow.dto.response;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+
+@Value
+@Builder
+public class ProjectResponseDTO {
+    Long id;
+    Long teamId;
+    String name;
+    String description;
+    LocalDate startDate;
+    LocalDate dueDate;
+    Instant createdAt;
+    Instant updatedAt;
+    List<TaskResponseDTO> tasks;
+}

--- a/src/main/java/com/example/TaskFlow/dto/response/TaskAssignmentDTO.java
+++ b/src/main/java/com/example/TaskFlow/dto/response/TaskAssignmentDTO.java
@@ -1,0 +1,16 @@
+package com.example.TaskFlow.dto.response;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.time.Instant;
+
+@Value
+@Builder
+public class TaskAssignmentDTO {
+    Long assigneeId;
+    Long delegateId;
+    Instant assignedAt;
+    Instant acknowledgedAt;
+    Instant completedAt;
+}

--- a/src/main/java/com/example/TaskFlow/dto/response/TaskResponseDTO.java
+++ b/src/main/java/com/example/TaskFlow/dto/response/TaskResponseDTO.java
@@ -1,0 +1,28 @@
+package com.example.TaskFlow.dto.response;
+
+import com.example.TaskFlow.model.enums.TaskPriority;
+import com.example.TaskFlow.model.enums.TaskStatus;
+import lombok.Builder;
+import lombok.Value;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+
+@Value
+@Builder
+public class TaskResponseDTO {
+    Long id;
+    Long projectId;
+    String title;
+    String description;
+    TaskStatus status;
+    TaskPriority priority;
+    LocalDate dueDate;
+    Integer sortOrder;
+    TaskAssignmentDTO assignment;
+    Instant createdAt;
+    Instant updatedAt;
+    List<CommentResponseDTO> comments;
+    List<AttachmentResponseDTO> attachments;
+}

--- a/src/main/java/com/example/TaskFlow/dto/response/TeamResponseDTO.java
+++ b/src/main/java/com/example/TaskFlow/dto/response/TeamResponseDTO.java
@@ -1,0 +1,20 @@
+package com.example.TaskFlow.dto.response;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+
+@Value
+@Builder
+public class TeamResponseDTO {
+    Long id;
+    String name;
+    String description;
+    Set<Long> memberIds;
+    Instant createdAt;
+    Instant updatedAt;
+    List<ProjectResponseDTO> projects;
+}

--- a/src/main/java/com/example/TaskFlow/model/Attachment.java
+++ b/src/main/java/com/example/TaskFlow/model/Attachment.java
@@ -1,0 +1,51 @@
+package com.example.TaskFlow.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "task_attachments", schema = "taskflow_app")
+@Getter
+@Setter
+public class Attachment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "task_id")
+    private Task task;
+
+    @Column(name = "file_name", nullable = false, length = 255)
+    private String fileName;
+
+    @Column(name = "content_type", length = 100)
+    private String contentType;
+
+    @Column(name = "storage_url", nullable = false, length = 512)
+    private String storageUrl;
+
+    @Column(name = "file_size")
+    private Long fileSize;
+
+    @Column(name = "uploaded_at", nullable = false, updatable = false)
+    private Instant uploadedAt;
+
+    @PrePersist
+    void prePersist() {
+        this.uploadedAt = Instant.now();
+    }
+}

--- a/src/main/java/com/example/TaskFlow/model/Comment.java
+++ b/src/main/java/com/example/TaskFlow/model/Comment.java
@@ -1,0 +1,57 @@
+package com.example.TaskFlow.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "task_comments", schema = "taskflow_app")
+@Getter
+@Setter
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "task_id")
+    private Task task;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "author_id")
+    private User author;
+
+    @Column(nullable = false, length = 2000)
+    private String content;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+
+    @PrePersist
+    void prePersist() {
+        Instant now = Instant.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    void preUpdate() {
+        this.updatedAt = Instant.now();
+    }
+}

--- a/src/main/java/com/example/TaskFlow/model/Project.java
+++ b/src/main/java/com/example/TaskFlow/model/Project.java
@@ -1,0 +1,77 @@
+package com.example.TaskFlow.model;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "projects", schema = "taskflow_app")
+@Getter
+@Setter
+public class Project {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 128)
+    private String name;
+
+    @Column(length = 1024)
+    private String description;
+
+    @Column(name = "start_date")
+    private LocalDate startDate;
+
+    @Column(name = "due_date")
+    private LocalDate dueDate;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "team_id")
+    private Team team;
+
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("sortOrder ASC")
+    private List<Task> tasks = new ArrayList<>();
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+
+    @PrePersist
+    void prePersist() {
+        Instant now = Instant.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    void preUpdate() {
+        this.updatedAt = Instant.now();
+    }
+
+    public void addTask(Task task) {
+        tasks.add(task);
+        task.setProject(this);
+    }
+}

--- a/src/main/java/com/example/TaskFlow/model/Task.java
+++ b/src/main/java/com/example/TaskFlow/model/Task.java
@@ -1,0 +1,93 @@
+package com.example.TaskFlow.model;
+
+import com.example.TaskFlow.model.enums.TaskPriority;
+import com.example.TaskFlow.model.enums.TaskStatus;
+import com.example.TaskFlow.model.value.AssignmentMetadata;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "tasks", schema = "taskflow_app")
+@Getter
+@Setter
+public class Task {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(length = 4000)
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 32)
+    private TaskStatus status = TaskStatus.BACKLOG;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 16)
+    private TaskPriority priority = TaskPriority.MEDIUM;
+
+    @Embedded
+    private AssignmentMetadata assignment = new AssignmentMetadata();
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "project_id")
+    private Project project;
+
+    @OneToMany(mappedBy = "task", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("createdAt ASC")
+    private List<Comment> comments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "task", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("uploadedAt ASC")
+    private List<Attachment> attachments = new ArrayList<>();
+
+    @Column(name = "due_date")
+    private LocalDate dueDate;
+
+    @Column(name = "sort_order")
+    private Integer sortOrder;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+
+    @PrePersist
+    void prePersist() {
+        Instant now = Instant.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    void preUpdate() {
+        this.updatedAt = Instant.now();
+    }
+}

--- a/src/main/java/com/example/TaskFlow/model/Team.java
+++ b/src/main/java/com/example/TaskFlow/model/Team.java
@@ -1,0 +1,90 @@
+package com.example.TaskFlow.model;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Entity
+@Table(name = "teams", schema = "taskflow_app",
+        uniqueConstraints = {@UniqueConstraint(name = "uk_team_name", columnNames = "name")})
+@Getter
+@Setter
+public class Team {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 128)
+    private String name;
+
+    @Column(length = 512)
+    private String description;
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+            name = "team_members",
+            schema = "taskflow_app",
+            joinColumns = @JoinColumn(name = "team_id"),
+            inverseJoinColumns = @JoinColumn(name = "user_id")
+    )
+    private Set<User> members = new HashSet<>();
+
+    @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("createdAt ASC")
+    private List<Project> projects = new ArrayList<>();
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+
+    @PrePersist
+    void prePersist() {
+        Instant now = Instant.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    void preUpdate() {
+        this.updatedAt = Instant.now();
+    }
+
+    public void addMember(User user) {
+        members.add(user);
+        user.getTeams().add(this);
+    }
+
+    public void removeMember(User user) {
+        members.remove(user);
+        user.getTeams().remove(this);
+    }
+
+    public void addProject(Project project) {
+        projects.add(project);
+        project.setTeam(this);
+    }
+}

--- a/src/main/java/com/example/TaskFlow/model/User.java
+++ b/src/main/java/com/example/TaskFlow/model/User.java
@@ -1,5 +1,6 @@
 package com.example.TaskFlow.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Size;
@@ -7,6 +8,9 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+
+import java.util.HashSet;
+import java.util.Set;
 
 // This class represents a User entity in the database
 // It is mapped to the "users" table in the "taskflow_auth" schema
@@ -78,5 +82,11 @@ public class User {
 
     @Column(name = "failed_login_attempts")
     private Integer failedLoginAttempts;
+
+    @ManyToMany(mappedBy = "members")
+    @JsonIgnore
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
+    private Set<Team> teams = new HashSet<>();
 
 }

--- a/src/main/java/com/example/TaskFlow/model/enums/TaskPriority.java
+++ b/src/main/java/com/example/TaskFlow/model/enums/TaskPriority.java
@@ -1,0 +1,11 @@
+package com.example.TaskFlow.model.enums;
+
+/**
+ * Represents the urgency and impact a task carries on the board.
+ */
+public enum TaskPriority {
+    LOW,
+    MEDIUM,
+    HIGH,
+    CRITICAL
+}

--- a/src/main/java/com/example/TaskFlow/model/enums/TaskStatus.java
+++ b/src/main/java/com/example/TaskFlow/model/enums/TaskStatus.java
@@ -1,0 +1,45 @@
+package com.example.TaskFlow.model.enums;
+
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Represents the lifecycle states a task can move through in the Kanban workflow.
+ * Each status declares the set of states it is allowed to transition to which can
+ * be used by services or validators to enforce business rules.
+ */
+public enum TaskStatus {
+    BACKLOG,
+    TODO,
+    IN_PROGRESS,
+    BLOCKED,
+    REVIEW,
+    DONE,
+    ARCHIVED;
+
+    private static final Map<TaskStatus, Set<TaskStatus>> ALLOWED_TRANSITIONS = buildTransitions();
+
+    private static Map<TaskStatus, Set<TaskStatus>> buildTransitions() {
+        Map<TaskStatus, Set<TaskStatus>> transitions = new EnumMap<>(TaskStatus.class);
+        transitions.put(BACKLOG, EnumSet.of(TODO, ARCHIVED));
+        transitions.put(TODO, EnumSet.of(IN_PROGRESS, BLOCKED, ARCHIVED));
+        transitions.put(IN_PROGRESS, EnumSet.of(BLOCKED, REVIEW, DONE, ARCHIVED));
+        transitions.put(BLOCKED, EnumSet.of(TODO, IN_PROGRESS, ARCHIVED));
+        transitions.put(REVIEW, EnumSet.of(IN_PROGRESS, DONE, ARCHIVED));
+        transitions.put(DONE, EnumSet.of(ARCHIVED));
+        transitions.put(ARCHIVED, EnumSet.noneOf(TaskStatus.class));
+        return transitions;
+    }
+
+    /**
+     * Determines whether a task can move from the current status to the provided status.
+     *
+     * @param next the status that is being targeted
+     * @return {@code true} when the transition is valid, otherwise {@code false}
+     */
+    public boolean canTransitionTo(TaskStatus next) {
+        return ALLOWED_TRANSITIONS.getOrDefault(this, EnumSet.noneOf(TaskStatus.class)).contains(next);
+    }
+}

--- a/src/main/java/com/example/TaskFlow/model/value/AssignmentMetadata.java
+++ b/src/main/java/com/example/TaskFlow/model/value/AssignmentMetadata.java
@@ -1,0 +1,56 @@
+package com.example.TaskFlow.model.value;
+
+import com.example.TaskFlow.model.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.io.Serializable;
+import java.time.Instant;
+
+/**
+ * Value object that encapsulates metadata about who a task is assigned to and
+ * important lifecycle timestamps for the assignment.
+ */
+@Embeddable
+@Getter
+@Setter
+public class AssignmentMetadata implements Serializable {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "assignee_id")
+    private User assignee;
+
+    @JoinColumn(name = "delegate_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User delegate;
+
+    @Column(name = "assigned_at")
+    private Instant assignedAt;
+
+    @Column(name = "acknowledged_at")
+    private Instant acknowledgedAt;
+
+    @Column(name = "completed_at")
+    private Instant completedAt;
+
+    @PrePersist
+    void onPersist() {
+        if (assignedAt == null && assignee != null) {
+            assignedAt = Instant.now();
+        }
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        if (acknowledgedAt != null && completedAt != null && acknowledgedAt.isAfter(completedAt)) {
+            acknowledgedAt = completedAt;
+        }
+    }
+}

--- a/src/main/java/com/example/TaskFlow/repo/AttachmentRepository.java
+++ b/src/main/java/com/example/TaskFlow/repo/AttachmentRepository.java
@@ -1,0 +1,10 @@
+package com.example.TaskFlow.repo;
+
+import com.example.TaskFlow.model.Attachment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AttachmentRepository extends JpaRepository<Attachment, Long> {
+    List<Attachment> findByTaskId(Long taskId);
+}

--- a/src/main/java/com/example/TaskFlow/repo/CommentRepository.java
+++ b/src/main/java/com/example/TaskFlow/repo/CommentRepository.java
@@ -1,0 +1,10 @@
+package com.example.TaskFlow.repo;
+
+import com.example.TaskFlow.model.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findByTaskIdOrderByCreatedAtAsc(Long taskId);
+}

--- a/src/main/java/com/example/TaskFlow/repo/ProjectRepository.java
+++ b/src/main/java/com/example/TaskFlow/repo/ProjectRepository.java
@@ -1,0 +1,12 @@
+package com.example.TaskFlow.repo;
+
+import com.example.TaskFlow.model.Project;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+    List<Project> findByTeamId(Long teamId);
+
+    List<Project> findByNameContainingIgnoreCase(String name);
+}

--- a/src/main/java/com/example/TaskFlow/repo/TaskRepository.java
+++ b/src/main/java/com/example/TaskFlow/repo/TaskRepository.java
@@ -1,0 +1,15 @@
+package com.example.TaskFlow.repo;
+
+import com.example.TaskFlow.model.Task;
+import com.example.TaskFlow.model.enums.TaskStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TaskRepository extends JpaRepository<Task, Long> {
+    List<Task> findByProjectIdOrderBySortOrderAsc(Long projectId);
+
+    List<Task> findByAssignmentAssigneeId(Long assigneeId);
+
+    List<Task> findByStatus(TaskStatus status);
+}

--- a/src/main/java/com/example/TaskFlow/repo/TeamRepository.java
+++ b/src/main/java/com/example/TaskFlow/repo/TeamRepository.java
@@ -1,0 +1,13 @@
+package com.example.TaskFlow.repo;
+
+import com.example.TaskFlow.model.Team;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TeamRepository extends JpaRepository<Team, Long> {
+    Optional<Team> findByName(String name);
+
+    List<Team> findByMembersId(Long memberId);
+}

--- a/src/test/java/com/example/TaskFlow/repo/TeamProjectTaskRepositoryTests.java
+++ b/src/test/java/com/example/TaskFlow/repo/TeamProjectTaskRepositoryTests.java
@@ -1,0 +1,149 @@
+package com.example.TaskFlow.repo;
+
+import com.example.TaskFlow.model.Attachment;
+import com.example.TaskFlow.model.Comment;
+import com.example.TaskFlow.model.Project;
+import com.example.TaskFlow.model.Task;
+import com.example.TaskFlow.model.Team;
+import com.example.TaskFlow.model.User;
+import com.example.TaskFlow.model.enums.TaskPriority;
+import com.example.TaskFlow.model.enums.TaskStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class TeamProjectTaskRepositoryTests {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private TaskRepository taskRepository;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private AttachmentRepository attachmentRepository;
+
+    @Test
+    void shouldPersistProjectWithTaskHierarchy() {
+        User owner = persistUser("owner");
+
+        Team team = new Team();
+        team.setName("Platform");
+        team.setDescription("Core platform initiatives");
+        team.addMember(owner);
+        team = teamRepository.saveAndFlush(team);
+
+        Project project = new Project();
+        project.setName("Service Mesh");
+        project.setDescription("Roll out mesh for internal services");
+        project.setStartDate(LocalDate.now());
+        project.setDueDate(LocalDate.now().plusDays(30));
+        team.addProject(project);
+
+        Task task = new Task();
+        task.setTitle("Design rollout plan");
+        task.setDescription("Prepare RFC covering rollout phases");
+        task.setStatus(TaskStatus.TODO);
+        task.setPriority(TaskPriority.HIGH);
+        task.setDueDate(LocalDate.now().plusDays(14));
+        task.setSortOrder(5);
+        task.getAssignment().setAssignee(owner);
+        task.getAssignment().setAssignedAt(Instant.now());
+
+        Comment comment = new Comment();
+        comment.setAuthor(owner);
+        comment.setTask(task);
+        comment.setContent("Kick-off scheduled with stakeholders.");
+        task.getComments().add(comment);
+
+        Attachment attachment = new Attachment();
+        attachment.setTask(task);
+        attachment.setFileName("rollout-plan.pdf");
+        attachment.setContentType("application/pdf");
+        attachment.setStorageUrl("https://files.local/rollout-plan.pdf");
+        attachment.setFileSize(2048L);
+        task.getAttachments().add(attachment);
+
+        project.addTask(task);
+        projectRepository.saveAndFlush(project);
+
+        List<Project> persistedProjects = projectRepository.findByTeamId(team.getId());
+        assertThat(persistedProjects).hasSize(1);
+        assertThat(persistedProjects.get(0).getTasks()).hasSize(1);
+
+        List<Task> persistedTasks = taskRepository.findByProjectIdOrderBySortOrderAsc(project.getId());
+        assertThat(persistedTasks).hasSize(1);
+        Task persistedTask = persistedTasks.get(0);
+        assertThat(persistedTask.getAssignment().getAssignee()).isNotNull();
+        assertThat(commentRepository.findByTaskIdOrderByCreatedAtAsc(persistedTask.getId()))
+                .hasSize(1)
+                .allMatch(stored -> stored.getContent().contains("Kick-off"));
+        assertThat(attachmentRepository.findByTaskId(persistedTask.getId()))
+                .hasSize(1)
+                .extracting(Attachment::getFileName)
+                .contains("rollout-plan.pdf");
+    }
+
+    @Test
+    void shouldFindTeamsAndTasksByMembership() {
+        User primary = persistUser("primary");
+        User collaborator = persistUser("collab");
+
+        Team team = new Team();
+        team.setName("Mobile");
+        team.addMember(primary);
+        team.addMember(collaborator);
+        team = teamRepository.saveAndFlush(team);
+
+        Project project = new Project();
+        project.setName("Mobile App");
+        project.setDescription("Rebuild onboarding flow");
+        team.addProject(project);
+
+        Task task = new Task();
+        task.setTitle("Implement biometric login");
+        task.setStatus(TaskStatus.IN_PROGRESS);
+        task.setPriority(TaskPriority.MEDIUM);
+        task.setSortOrder(1);
+        task.getAssignment().setAssignee(collaborator);
+        task.getAssignment().setAssignedAt(Instant.now());
+        project.addTask(task);
+
+        projectRepository.saveAndFlush(project);
+
+        assertThat(teamRepository.findByMembersId(primary.getId()))
+                .extracting(Team::getId)
+                .contains(team.getId());
+
+        assertThat(taskRepository.findByAssignmentAssigneeId(collaborator.getId()))
+                .extracting(Task::getTitle)
+                .contains("Implement biometric login");
+    }
+
+    private User persistUser(String seed) {
+        User user = new User();
+        user.setEmail(seed + "@example.com");
+        user.setUsername(seed);
+        user.setPasswordHash("secret");
+        user.setFirstname("First");
+        user.setLastname("User");
+        user.setIsActive(true);
+        return userRepository.saveAndFlush(user);
+    }
+}


### PR DESCRIPTION
## Summary
- add Team, Project, Task, Comment, and Attachment entities with workflow enums and assignment metadata
- introduce DTOs and Spring Data repositories for teams, projects, tasks, comments, and attachments
- document the new ER model and cover repository interactions with JPA tests (adds H2 for testing)

## Testing
- ./mvnw test *(fails: cannot reach Maven Central from the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d367513c90832ab315ab87e89a0fd1