### PR TITLE
Implement task and team management services

### DIFF
--- a/src/main/java/com/example/TaskFlow/config/SecurityConfig.java
+++ b/src/main/java/com/example/TaskFlow/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.example.TaskFlow.jwt.JwtAuthFilter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -17,6 +18,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 // @EnableWebSecurity: Enables Spring Security's web security support
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 public class SecurityConfig {
 
     private final JwtAuthFilter jwtAuthFilter;
@@ -39,6 +41,7 @@ public class SecurityConfig {
                 // Permiting all requests to /auth/** endpoints
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/auth/**","/swagger-ui/**","/v3/api-docs/**","/v3/api-docs.yaml","/swagger-ui.html").permitAll()
+                        .requestMatchers("/api/tasks/**", "/api/teams/**").hasAnyRole("ADMIN","MEMBER")
                         .anyRequest().authenticated())
                 // No session will be created or used by Spring Security
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS));

--- a/src/main/java/com/example/TaskFlow/config/SecurityConfig.java
+++ b/src/main/java/com/example/TaskFlow/config/SecurityConfig.java
@@ -41,7 +41,7 @@ public class SecurityConfig {
                 // Permiting all requests to /auth/** endpoints
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/auth/**","/swagger-ui/**","/v3/api-docs/**","/v3/api-docs.yaml","/swagger-ui.html").permitAll()
-                        .requestMatchers("/api/tasks/**", "/api/teams/**").hasAnyRole("ADMIN","MEMBER")
+                        .requestMatchers("/api/tasks/**", "/api/teams/**", "/api/projects/**").hasAnyRole("ADMIN","MEMBER")
                         .anyRequest().authenticated())
                 // No session will be created or used by Spring Security
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS));

--- a/src/main/java/com/example/TaskFlow/controller/ProjectController.java
+++ b/src/main/java/com/example/TaskFlow/controller/ProjectController.java
@@ -1,0 +1,85 @@
+package com.example.TaskFlow.controller;
+
+import com.example.TaskFlow.dto.request.ProjectRequestDTO;
+import com.example.TaskFlow.dto.response.ProjectResponseDTO;
+import com.example.TaskFlow.service.ProjectService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "Projects", description = "Endpoints for managing projects within teams.")
+@SecurityRequirement(name = "bearerAuth")
+@RestController
+@RequestMapping("/api/projects")
+public class ProjectController {
+
+    private final ProjectService projectService;
+
+    public ProjectController(ProjectService projectService) {
+        this.projectService = projectService;
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('ADMIN','MEMBER')")
+    @Operation(summary = "List projects", description = "Lists projects for the specified team.")
+    public List<ProjectResponseDTO> listProjects(@RequestParam Long teamId, Authentication authentication) {
+        return projectService.listProjects(teamId, authentication.getName());
+    }
+
+    @GetMapping("/{projectId}")
+    @PreAuthorize("hasAnyRole('ADMIN','MEMBER')")
+    @Operation(summary = "Get a project", description = "Fetches a single project with its metadata.")
+    public ProjectResponseDTO getProject(@PathVariable Long projectId, Authentication authentication) {
+        return projectService.getProject(projectId, authentication.getName());
+    }
+
+    @PostMapping
+    @PreAuthorize("hasAnyRole('ADMIN','MEMBER')")
+    @Operation(summary = "Create a project", description = "Creates a new project for a team.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Project created",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProjectResponseDTO.class)))
+    })
+    public ResponseEntity<ProjectResponseDTO> createProject(@Valid @RequestBody ProjectRequestDTO request,
+                                                            Authentication authentication) {
+        ProjectResponseDTO response = projectService.createProject(request, authentication.getName());
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PutMapping("/{projectId}")
+    @PreAuthorize("hasAnyRole('ADMIN','MEMBER')")
+    @Operation(summary = "Update a project", description = "Updates the details of an existing project.")
+    public ProjectResponseDTO updateProject(@PathVariable Long projectId,
+                                            @Valid @RequestBody ProjectRequestDTO request,
+                                            Authentication authentication) {
+        return projectService.updateProject(projectId, request, authentication.getName());
+    }
+
+    @DeleteMapping("/{projectId}")
+    @PreAuthorize("hasAnyRole('ADMIN','MEMBER')")
+    @Operation(summary = "Delete a project", description = "Deletes a project and its tasks.")
+    public ResponseEntity<Void> deleteProject(@PathVariable Long projectId, Authentication authentication) {
+        projectService.deleteProject(projectId, authentication.getName());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/example/TaskFlow/controller/TaskController.java
+++ b/src/main/java/com/example/TaskFlow/controller/TaskController.java
@@ -1,0 +1,96 @@
+package com.example.TaskFlow.controller;
+
+import com.example.TaskFlow.dto.request.TaskReorderRequestDTO;
+import com.example.TaskFlow.dto.request.TaskRequestDTO;
+import com.example.TaskFlow.dto.request.TaskStatusUpdateRequestDTO;
+import com.example.TaskFlow.dto.response.TaskResponseDTO;
+import com.example.TaskFlow.model.enums.TaskStatus;
+import com.example.TaskFlow.service.TaskService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Optional;
+
+@Tag(name = "Tasks", description = "Endpoints for managing tasks within TaskFlow projects.")
+@SecurityRequirement(name = "bearerAuth")
+@RestController
+@RequestMapping("/api/tasks")
+public class TaskController {
+
+    private final TaskService taskService;
+
+    public TaskController(TaskService taskService) {
+        this.taskService = taskService;
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('ADMIN','MEMBER')")
+    @Operation(summary = "List tasks", description = "Fetches tasks with optional filters for project, status and assignee.")
+    public List<TaskResponseDTO> listTasks(@RequestParam(required = false) Long projectId,
+                                           @RequestParam(required = false) TaskStatus status,
+                                           @RequestParam(required = false) Long assigneeId) {
+        return taskService.getTasks(projectId, Optional.ofNullable(status), Optional.ofNullable(assigneeId));
+    }
+
+    @PostMapping
+    @PreAuthorize("hasAnyRole('ADMIN','MEMBER')")
+    @Operation(summary = "Create a task", description = "Creates a new task within the specified project.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Task created",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = TaskResponseDTO.class)))
+    })
+    public ResponseEntity<TaskResponseDTO> createTask(@Valid @RequestBody TaskRequestDTO request) {
+        TaskResponseDTO response = taskService.createTask(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PutMapping("/{taskId}")
+    @PreAuthorize("hasAnyRole('ADMIN','MEMBER')")
+    @Operation(summary = "Update a task", description = "Updates the specified task's details and attachments.")
+    public TaskResponseDTO updateTask(@PathVariable Long taskId, @Valid @RequestBody TaskRequestDTO request) {
+        return taskService.updateTask(taskId, request);
+    }
+
+    @DeleteMapping("/{taskId}")
+    @PreAuthorize("hasAnyRole('ADMIN','MEMBER')")
+    @Operation(summary = "Delete a task", description = "Deletes the specified task from its project.")
+    public ResponseEntity<Void> deleteTask(@PathVariable Long taskId) {
+        taskService.deleteTask(taskId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/reorder")
+    @PreAuthorize("hasAnyRole('ADMIN','MEMBER')")
+    @Operation(summary = "Reorder tasks", description = "Reorders tasks within a kanban column using their new sort order.")
+    public List<TaskResponseDTO> reorder(@Valid @RequestBody TaskReorderRequestDTO request) {
+        return taskService.reorderTasks(request);
+    }
+
+    @PatchMapping("/{taskId}/status")
+    @PreAuthorize("hasAnyRole('ADMIN','MEMBER')")
+    @Operation(summary = "Update task status", description = "Transitions a task to a new status if allowed by the workflow.")
+    public TaskResponseDTO updateStatus(@PathVariable Long taskId,
+                                        @Valid @RequestBody TaskStatusUpdateRequestDTO request) {
+        return taskService.changeStatus(taskId, request.status());
+    }
+}

--- a/src/main/java/com/example/TaskFlow/controller/TeamController.java
+++ b/src/main/java/com/example/TaskFlow/controller/TeamController.java
@@ -1,0 +1,104 @@
+package com.example.TaskFlow.controller;
+
+import com.example.TaskFlow.dto.request.TeamCreateRequestDTO;
+import com.example.TaskFlow.dto.request.TeamInviteRequestDTO;
+import com.example.TaskFlow.dto.request.TeamInvitationResponseDTO;
+import com.example.TaskFlow.dto.request.TeamRoleUpdateRequestDTO;
+import com.example.TaskFlow.dto.response.TeamMembershipResponseDTO;
+import com.example.TaskFlow.dto.response.TeamResponseDTO;
+import com.example.TaskFlow.service.TeamService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "Teams", description = "Operations for managing teams and memberships.")
+@SecurityRequirement(name = "bearerAuth")
+@RestController
+@RequestMapping("/api/teams")
+public class TeamController {
+
+    private final TeamService teamService;
+
+    public TeamController(TeamService teamService) {
+        this.teamService = teamService;
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('ADMIN','MEMBER')")
+    @Operation(summary = "List teams", description = "Returns all teams the authenticated user belongs to.")
+    public List<TeamResponseDTO> listTeams() {
+        return teamService.getTeamsForUser(currentUsername());
+    }
+
+    @PostMapping
+    @PreAuthorize("hasAnyRole('ADMIN','MEMBER')")
+    @Operation(summary = "Create a team", description = "Creates a new team with the authenticated user as administrator.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Team created",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = TeamResponseDTO.class)))
+    })
+    public ResponseEntity<TeamResponseDTO> createTeam(@Valid @RequestBody TeamCreateRequestDTO request) {
+        TeamResponseDTO response = teamService.createTeam(request, currentUsername());
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PostMapping("/{teamId}/invite")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Invite a member", description = "Invites a user to join the specified team.")
+    public TeamResponseDTO inviteMember(@PathVariable Long teamId, @Valid @RequestBody TeamInviteRequestDTO request) {
+        return teamService.inviteMember(teamId, request, currentUsername());
+    }
+
+    @PostMapping("/invitations/{membershipId}/respond")
+    @PreAuthorize("hasAnyRole('ADMIN','MEMBER')")
+    @Operation(summary = "Respond to invitation", description = "Accepts or declines a pending team invitation.")
+    public TeamMembershipResponseDTO respondToInvitation(@PathVariable Long membershipId,
+                                                         @Valid @RequestBody TeamInvitationResponseDTO request) {
+        return teamService.respondToInvitation(membershipId, request, currentUsername());
+    }
+
+    @PutMapping("/{teamId}/members/{memberId}/role")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Update member role", description = "Changes the role of a team member.")
+    public TeamResponseDTO updateRole(@PathVariable Long teamId,
+                                      @PathVariable Long memberId,
+                                      @Valid @RequestBody TeamRoleUpdateRequestDTO request) {
+        return teamService.updateMemberRole(teamId, memberId, request, currentUsername());
+    }
+
+    @DeleteMapping("/{teamId}/members/{memberId}")
+    @PreAuthorize("hasAnyRole('ADMIN','MEMBER')")
+    @Operation(summary = "Remove member", description = "Removes a member from the team or declines an invitation.")
+    public ResponseEntity<Void> removeMember(@PathVariable Long teamId, @PathVariable Long memberId) {
+        teamService.removeMember(teamId, memberId, currentUsername());
+        return ResponseEntity.noContent().build();
+    }
+
+    private String currentUsername() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || authentication.getName() == null) {
+            throw new IllegalStateException("Authentication is required");
+        }
+        return authentication.getName();
+    }
+}

--- a/src/main/java/com/example/TaskFlow/controller/TeamController.java
+++ b/src/main/java/com/example/TaskFlow/controller/TeamController.java
@@ -15,6 +15,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -36,6 +39,8 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/teams")
 public class TeamController {
+
+    private final static Logger logger = LoggerFactory.getLogger(TeamController.class);
 
     private final TeamService teamService;
 

--- a/src/main/java/com/example/TaskFlow/dto/mapper/ProjectMapper.java
+++ b/src/main/java/com/example/TaskFlow/dto/mapper/ProjectMapper.java
@@ -1,0 +1,41 @@
+package com.example.TaskFlow.dto.mapper;
+
+import com.example.TaskFlow.dto.request.ProjectRequestDTO;
+import com.example.TaskFlow.dto.response.ProjectResponseDTO;
+import com.example.TaskFlow.model.Project;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProjectMapper {
+
+    private final TaskMapper taskMapper;
+
+    @Autowired
+    public ProjectMapper(TaskMapper taskMapper) {
+        this.taskMapper = taskMapper;
+    }
+
+    public ProjectResponseDTO toResponse(Project project) {
+        return ProjectResponseDTO.builder()
+                .id(project.getId())
+                .teamId(project.getTeam() != null ? project.getTeam().getId() : null)
+                .name(project.getName())
+                .description(project.getDescription())
+                .startDate(project.getStartDate())
+                .dueDate(project.getDueDate())
+                .createdAt(project.getCreatedAt())
+                .updatedAt(project.getUpdatedAt())
+                .tasks(project.getTasks() != null ? project.getTasks().stream()
+                        .map(taskMapper::toResponse)
+                        .toList() : null)
+                .build();
+    }
+
+    public void applyUpsert(ProjectRequestDTO request, Project project) {
+        project.setName(request.getName().trim());
+        project.setDescription(request.getDescription());
+        project.setStartDate(request.getStartDate());
+        project.setDueDate(request.getDueDate());
+    }
+}

--- a/src/main/java/com/example/TaskFlow/dto/mapper/TaskMapper.java
+++ b/src/main/java/com/example/TaskFlow/dto/mapper/TaskMapper.java
@@ -1,0 +1,128 @@
+package com.example.TaskFlow.dto.mapper;
+
+import com.example.TaskFlow.dto.request.AttachmentPayloadDTO;
+import com.example.TaskFlow.dto.request.TaskRequestDTO;
+import com.example.TaskFlow.dto.response.AttachmentResponseDTO;
+import com.example.TaskFlow.dto.response.TaskAssignmentDTO;
+import com.example.TaskFlow.dto.response.TaskResponseDTO;
+import com.example.TaskFlow.model.Attachment;
+import com.example.TaskFlow.model.Task;
+import com.example.TaskFlow.model.User;
+import com.example.TaskFlow.model.value.AssignmentMetadata;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Objects;
+
+@Component
+public class TaskMapper {
+
+    public TaskResponseDTO toResponse(Task task) {
+        AssignmentMetadata assignment = task.getAssignment();
+        TaskAssignmentDTO assignmentDTO = null;
+        if (assignment != null) {
+            assignmentDTO = new TaskAssignmentDTO(
+                    assignment.getAssignee() != null ? assignment.getAssignee().getId() : null,
+                    assignment.getDelegate() != null ? assignment.getDelegate().getId() : null,
+                    assignment.getAssignedAt(),
+                    assignment.getAcknowledgedAt(),
+                    assignment.getCompletedAt()
+            );
+        }
+
+        List<AttachmentResponseDTO> attachments = task.getAttachments().stream()
+                .map(this::toAttachmentResponse)
+                .toList();
+
+        return TaskResponseDTO.builder()
+                .id(task.getId())
+                .projectId(task.getProject() != null ? task.getProject().getId() : null)
+                .title(task.getTitle())
+                .description(task.getDescription())
+                .status(task.getStatus())
+                .priority(task.getPriority())
+                .dueDate(task.getDueDate())
+                .sortOrder(task.getSortOrder())
+                .assignment(assignmentDTO)
+                .createdAt(task.getCreatedAt())
+                .updatedAt(task.getUpdatedAt())
+                .comments(task.getComments().stream()
+                        .map(comment -> com.example.TaskFlow.dto.response.CommentResponseDTO.builder()
+                                .id(comment.getId())
+                                .taskId(comment.getTask() != null ? comment.getTask().getId() : null)
+                                .authorId(comment.getAuthor() != null ? comment.getAuthor().getId() : null)
+                                .content(comment.getContent())
+                                .createdAt(comment.getCreatedAt())
+                                .updatedAt(comment.getUpdatedAt())
+                                .build())
+                        .toList())
+                .attachments(attachments)
+                .build();
+    }
+
+    public void applyUpsert(TaskRequestDTO dto, Task task, User assignee, User delegate) {
+        task.setTitle(dto.getTitle());
+        task.setDescription(dto.getDescription());
+        if (dto.getStatus() != null) {
+            task.setStatus(dto.getStatus());
+        }
+        if (dto.getPriority() != null) {
+            task.setPriority(dto.getPriority());
+        }
+        task.setDueDate(dto.getDueDate());
+        task.setSortOrder(dto.getSortOrder());
+
+        AssignmentMetadata assignment = task.getAssignment();
+        if (assignment == null) {
+            assignment = new AssignmentMetadata();
+            task.setAssignment(assignment);
+        }
+        assignment.setAssignee(assignee);
+        assignment.setDelegate(delegate);
+        if (dto.getAssignedAt() != null) {
+            assignment.setAssignedAt(dto.getAssignedAt());
+        }
+        if (dto.getAcknowledgedAt() != null) {
+            assignment.setAcknowledgedAt(dto.getAcknowledgedAt());
+        }
+        if (dto.getCompletedAt() != null) {
+            assignment.setCompletedAt(dto.getCompletedAt());
+        }
+    }
+
+    public Attachment fromPayload(AttachmentPayloadDTO payload) {
+        Attachment attachment = new Attachment();
+        attachment.setFileName(payload.getFileName());
+        attachment.setContentType(payload.getContentType());
+        attachment.setStorageUrl(payload.getStorageUrl());
+        attachment.setFileSize(payload.getFileSize());
+        return attachment;
+    }
+
+    private AttachmentResponseDTO toAttachmentResponse(Attachment attachment) {
+        return AttachmentResponseDTO.builder()
+                .id(attachment.getId())
+                .taskId(attachment.getTask() != null ? attachment.getTask().getId() : null)
+                .fileName(attachment.getFileName())
+                .contentType(attachment.getContentType())
+                .storageUrl(attachment.getStorageUrl())
+                .fileSize(attachment.getFileSize())
+                .uploadedAt(attachment.getUploadedAt())
+                .build();
+    }
+
+    public void mergeAttachments(Task task, List<AttachmentPayloadDTO> payloads, List<Long> removeIds) {
+        if (removeIds != null && !removeIds.isEmpty()) {
+            task.getAttachments().removeIf(att -> removeIds.contains(att.getId()));
+        }
+        if (payloads != null) {
+            payloads.stream()
+                    .filter(Objects::nonNull)
+                    .map(this::fromPayload)
+                    .forEach(attachment -> {
+                        attachment.setTask(task);
+                        task.getAttachments().add(attachment);
+                    });
+        }
+    }
+}

--- a/src/main/java/com/example/TaskFlow/dto/mapper/TaskMapper.java
+++ b/src/main/java/com/example/TaskFlow/dto/mapper/TaskMapper.java
@@ -21,13 +21,16 @@ public class TaskMapper {
         AssignmentMetadata assignment = task.getAssignment();
         TaskAssignmentDTO assignmentDTO = null;
         if (assignment != null) {
+            /*
             assignmentDTO = new TaskAssignmentDTO(
                     assignment.getAssignee() != null ? assignment.getAssignee().getId() : null,
                     assignment.getDelegate() != null ? assignment.getDelegate().getId() : null,
                     assignment.getAssignedAt(),
                     assignment.getAcknowledgedAt(),
                     assignment.getCompletedAt()
+
             );
+             */
         }
 
         List<AttachmentResponseDTO> attachments = task.getAttachments().stream()

--- a/src/main/java/com/example/TaskFlow/dto/mapper/TeamMapper.java
+++ b/src/main/java/com/example/TaskFlow/dto/mapper/TeamMapper.java
@@ -1,0 +1,59 @@
+package com.example.TaskFlow.dto.mapper;
+
+import com.example.TaskFlow.dto.response.ProjectResponseDTO;
+import com.example.TaskFlow.dto.response.TeamMembershipResponseDTO;
+import com.example.TaskFlow.dto.response.TeamResponseDTO;
+import com.example.TaskFlow.model.Project;
+import com.example.TaskFlow.model.Team;
+import com.example.TaskFlow.model.TeamMembership;
+import org.springframework.stereotype.Component;
+
+import java.util.Comparator;
+
+@Component
+public class TeamMapper {
+
+    public TeamResponseDTO toResponse(Team team) {
+        TeamResponseDTO.TeamResponseDTOBuilder builder = TeamResponseDTO.builder()
+                .id(team.getId())
+                .name(team.getName())
+                .description(team.getDescription())
+                .createdAt(team.getCreatedAt())
+                .updatedAt(team.getUpdatedAt());
+
+        team.getMemberships().stream()
+                .sorted(Comparator.comparing(TeamMembership::getInvitedAt))
+                .map(this::toMembershipResponse)
+                .forEach(builder::member);
+
+        team.getProjects().stream()
+                .sorted(Comparator.comparing(Project::getCreatedAt, Comparator.nullsLast(Comparator.naturalOrder())))
+                .map(this::toProjectResponse)
+                .forEach(builder::project);
+
+        return builder.build();
+    }
+
+    private TeamMembershipResponseDTO toMembershipResponse(TeamMembership membership) {
+        return TeamMembershipResponseDTO.builder()
+                .id(membership.getId())
+                .userId(membership.getUser() != null ? membership.getUser().getId() : null)
+                .username(membership.getUser() != null ? membership.getUser().getUsername() : null)
+                .role(membership.getRole())
+                .status(membership.getStatus())
+                .invitedAt(membership.getInvitedAt())
+                .joinedAt(membership.getJoinedAt())
+                .respondedAt(membership.getRespondedAt())
+                .build();
+    }
+
+    private ProjectResponseDTO toProjectResponse(Project project) {
+        return ProjectResponseDTO.builder()
+                .id(project.getId())
+                .name(project.getName())
+                .description(project.getDescription())
+                .startDate(project.getStartDate())
+                .dueDate(project.getDueDate())
+                .build();
+    }
+}

--- a/src/main/java/com/example/TaskFlow/dto/request/AttachmentPayloadDTO.java
+++ b/src/main/java/com/example/TaskFlow/dto/request/AttachmentPayloadDTO.java
@@ -1,0 +1,23 @@
+package com.example.TaskFlow.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class AttachmentPayloadDTO {
+    @NotBlank
+    @Size(max = 255)
+    private String fileName;
+
+    @Size(max = 100)
+    private String contentType;
+
+    @NotBlank
+    @Size(max = 512)
+    private String storageUrl;
+
+    @NotNull
+    private Long fileSize;
+}

--- a/src/main/java/com/example/TaskFlow/dto/request/TaskReorderRequestDTO.java
+++ b/src/main/java/com/example/TaskFlow/dto/request/TaskReorderRequestDTO.java
@@ -1,0 +1,33 @@
+package com.example.TaskFlow.dto.request;
+
+import com.example.TaskFlow.model.enums.TaskStatus;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class TaskReorderRequestDTO {
+    @NotNull
+    private Long projectId;
+
+    @NotNull
+    private TaskStatus status;
+
+    @NotEmpty
+    @Valid
+    private List<PositionDTO> positions;
+
+    @Data
+    public static class PositionDTO {
+        @NotNull
+        private Long taskId;
+
+        @NotNull
+        @Min(0)
+        private Integer sortOrder;
+    }
+}

--- a/src/main/java/com/example/TaskFlow/dto/request/TaskRequestDTO.java
+++ b/src/main/java/com/example/TaskFlow/dto/request/TaskRequestDTO.java
@@ -9,6 +9,7 @@ import lombok.Data;
 
 import java.time.Instant;
 import java.time.LocalDate;
+import java.util.List;
 
 @Data
 public class TaskRequestDTO {
@@ -40,4 +41,8 @@ public class TaskRequestDTO {
     private LocalDate dueDate;
 
     private Integer sortOrder;
+
+    private List<AttachmentPayloadDTO> attachments;
+
+    private List<Long> removeAttachmentIds;
 }

--- a/src/main/java/com/example/TaskFlow/dto/request/TaskStatusUpdateRequestDTO.java
+++ b/src/main/java/com/example/TaskFlow/dto/request/TaskStatusUpdateRequestDTO.java
@@ -1,0 +1,7 @@
+package com.example.TaskFlow.dto.request;
+
+import com.example.TaskFlow.model.enums.TaskStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record TaskStatusUpdateRequestDTO(@NotNull TaskStatus status) {
+}

--- a/src/main/java/com/example/TaskFlow/dto/request/TeamCreateRequestDTO.java
+++ b/src/main/java/com/example/TaskFlow/dto/request/TeamCreateRequestDTO.java
@@ -1,0 +1,15 @@
+package com.example.TaskFlow.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class TeamCreateRequestDTO {
+    @NotBlank
+    @Size(max = 128)
+    private String name;
+
+    @Size(max = 512)
+    private String description;
+}

--- a/src/main/java/com/example/TaskFlow/dto/request/TeamInvitationResponseDTO.java
+++ b/src/main/java/com/example/TaskFlow/dto/request/TeamInvitationResponseDTO.java
@@ -1,0 +1,6 @@
+package com.example.TaskFlow.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record TeamInvitationResponseDTO(@NotNull Boolean accept) {
+}

--- a/src/main/java/com/example/TaskFlow/dto/request/TeamInviteRequestDTO.java
+++ b/src/main/java/com/example/TaskFlow/dto/request/TeamInviteRequestDTO.java
@@ -1,0 +1,13 @@
+package com.example.TaskFlow.dto.request;
+
+import com.example.TaskFlow.model.enums.TeamRole;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class TeamInviteRequestDTO {
+    @NotNull
+    private Long userId;
+
+    private TeamRole role = TeamRole.MEMBER;
+}

--- a/src/main/java/com/example/TaskFlow/dto/request/TeamRoleUpdateRequestDTO.java
+++ b/src/main/java/com/example/TaskFlow/dto/request/TeamRoleUpdateRequestDTO.java
@@ -1,0 +1,7 @@
+package com.example.TaskFlow.dto.request;
+
+import com.example.TaskFlow.model.enums.TeamRole;
+import jakarta.validation.constraints.NotNull;
+
+public record TeamRoleUpdateRequestDTO(@NotNull TeamRole role) {
+}

--- a/src/main/java/com/example/TaskFlow/dto/response/TeamMembershipResponseDTO.java
+++ b/src/main/java/com/example/TaskFlow/dto/response/TeamMembershipResponseDTO.java
@@ -1,0 +1,21 @@
+package com.example.TaskFlow.dto.response;
+
+import com.example.TaskFlow.model.enums.MembershipStatus;
+import com.example.TaskFlow.model.enums.TeamRole;
+import lombok.Builder;
+import lombok.Value;
+
+import java.time.Instant;
+
+@Value
+@Builder
+public class TeamMembershipResponseDTO {
+    Long id;
+    Long userId;
+    String username;
+    TeamRole role;
+    MembershipStatus status;
+    Instant invitedAt;
+    Instant joinedAt;
+    Instant respondedAt;
+}

--- a/src/main/java/com/example/TaskFlow/dto/response/TeamResponseDTO.java
+++ b/src/main/java/com/example/TaskFlow/dto/response/TeamResponseDTO.java
@@ -1,11 +1,11 @@
 package com.example.TaskFlow.dto.response;
 
 import lombok.Builder;
+import lombok.Singular;
 import lombok.Value;
 
 import java.time.Instant;
 import java.util.List;
-import java.util.Set;
 
 @Value
 @Builder
@@ -13,8 +13,10 @@ public class TeamResponseDTO {
     Long id;
     String name;
     String description;
-    Set<Long> memberIds;
     Instant createdAt;
     Instant updatedAt;
+    @Singular
+    List<TeamMembershipResponseDTO> members;
+    @Singular
     List<ProjectResponseDTO> projects;
 }

--- a/src/main/java/com/example/TaskFlow/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/example/TaskFlow/jwt/JwtAuthFilter.java
@@ -52,6 +52,12 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
                                     FilterChain filterChain) throws IOException, ServletException {
 
+        if (SecurityContextHolder.getContext().getAuthentication() != null &&
+                SecurityContextHolder.getContext().getAuthentication().isAuthenticated()) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         String authHeader = request.getHeader("Authorization");
         System.out.println("Auth Header : "+authHeader);
         String auth_token = jwtService.extractTokenFromHeader(authHeader).orElse(null);

--- a/src/main/java/com/example/TaskFlow/model/TeamMembership.java
+++ b/src/main/java/com/example/TaskFlow/model/TeamMembership.java
@@ -1,0 +1,84 @@
+package com.example.TaskFlow.model;
+
+import com.example.TaskFlow.model.enums.MembershipStatus;
+import com.example.TaskFlow.model.enums.TeamRole;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "team_memberships", schema = "taskflow_app",
+        uniqueConstraints = @UniqueConstraint(name = "uk_team_member", columnNames = {"team_id", "user_id"}))
+@Getter
+@Setter
+public class TeamMembership {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "team_id")
+    private Team team;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "invited_by_id")
+    private User invitedBy;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 16)
+    private TeamRole role = TeamRole.MEMBER;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 16)
+    private MembershipStatus status = MembershipStatus.INVITED;
+
+    @Column(name = "invited_at", nullable = false, updatable = false)
+    private Instant invitedAt;
+
+    @Column(name = "responded_at")
+    private Instant respondedAt;
+
+    @Column(name = "joined_at")
+    private Instant joinedAt;
+
+    @PrePersist
+    void prePersist() {
+        if (invitedAt == null) {
+            invitedAt = Instant.now();
+        }
+    }
+
+    public void activate() {
+        this.status = MembershipStatus.ACTIVE;
+        this.joinedAt = Instant.now();
+        this.respondedAt = this.joinedAt;
+    }
+
+    public void decline() {
+        this.status = MembershipStatus.DECLINED;
+        this.respondedAt = Instant.now();
+    }
+
+    public boolean isActiveAdmin() {
+        return status == MembershipStatus.ACTIVE && role == TeamRole.ADMIN;
+    }
+}

--- a/src/main/java/com/example/TaskFlow/model/User.java
+++ b/src/main/java/com/example/TaskFlow/model/User.java
@@ -1,7 +1,16 @@
 package com.example.TaskFlow.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Size;
 import lombok.EqualsAndHashCode;
@@ -83,10 +92,10 @@ public class User {
     @Column(name = "failed_login_attempts")
     private Integer failedLoginAttempts;
 
-    @ManyToMany(mappedBy = "members")
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     @JsonIgnore
     @EqualsAndHashCode.Exclude
     @ToString.Exclude
-    private Set<Team> teams = new HashSet<>();
+    private Set<TeamMembership> memberships = new HashSet<>();
 
 }

--- a/src/main/java/com/example/TaskFlow/model/enums/MembershipStatus.java
+++ b/src/main/java/com/example/TaskFlow/model/enums/MembershipStatus.java
@@ -1,0 +1,15 @@
+package com.example.TaskFlow.model.enums;
+
+/**
+ * Lifecycle state of a team membership invitation.
+ */
+public enum MembershipStatus {
+    INVITED,
+    ACTIVE,
+    DECLINED,
+    REMOVED;
+
+    public boolean isActive() {
+        return this == ACTIVE;
+    }
+}

--- a/src/main/java/com/example/TaskFlow/model/enums/TeamRole.java
+++ b/src/main/java/com/example/TaskFlow/model/enums/TeamRole.java
@@ -1,0 +1,15 @@
+package com.example.TaskFlow.model.enums;
+
+/**
+ * Represents the permissions a team member has within the context of a team.
+ * Administrators can manage membership and projects while members are limited
+ * to collaborating on assigned work.
+ */
+public enum TeamRole {
+    ADMIN,
+    MEMBER;
+
+    public boolean isAdmin() {
+        return this == ADMIN;
+    }
+}

--- a/src/main/java/com/example/TaskFlow/repo/ProjectRepository.java
+++ b/src/main/java/com/example/TaskFlow/repo/ProjectRepository.java
@@ -9,4 +9,6 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
     List<Project> findByTeamId(Long teamId);
 
     List<Project> findByNameContainingIgnoreCase(String name);
+
+    boolean existsByTeamIdAndNameIgnoreCase(Long teamId, String name);
 }

--- a/src/main/java/com/example/TaskFlow/repo/TeamMembershipRepository.java
+++ b/src/main/java/com/example/TaskFlow/repo/TeamMembershipRepository.java
@@ -12,5 +12,5 @@ public interface TeamMembershipRepository extends JpaRepository<TeamMembership, 
 
     List<TeamMembership> findByTeamIdAndStatus(Long teamId, MembershipStatus status);
 
-    Optional<TeamMembership> findByTeamIdAndUserId(Long teamId, Long userId);
+    Optional<TeamMembership> findByTeam_IdAndUser_Id(Long teamId, Long userId);
 }

--- a/src/main/java/com/example/TaskFlow/repo/TeamMembershipRepository.java
+++ b/src/main/java/com/example/TaskFlow/repo/TeamMembershipRepository.java
@@ -1,0 +1,16 @@
+package com.example.TaskFlow.repo;
+
+import com.example.TaskFlow.model.TeamMembership;
+import com.example.TaskFlow.model.enums.MembershipStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TeamMembershipRepository extends JpaRepository<TeamMembership, Long> {
+    List<TeamMembership> findByUserIdAndStatus(Long userId, MembershipStatus status);
+
+    List<TeamMembership> findByTeamIdAndStatus(Long teamId, MembershipStatus status);
+
+    Optional<TeamMembership> findByTeamIdAndUserId(Long teamId, Long userId);
+}

--- a/src/main/java/com/example/TaskFlow/repo/TeamRepository.java
+++ b/src/main/java/com/example/TaskFlow/repo/TeamRepository.java
@@ -1,6 +1,7 @@
 package com.example.TaskFlow.repo;
 
 import com.example.TaskFlow.model.Team;
+import com.example.TaskFlow.model.enums.MembershipStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -9,5 +10,7 @@ import java.util.Optional;
 public interface TeamRepository extends JpaRepository<Team, Long> {
     Optional<Team> findByName(String name);
 
-    List<Team> findByMembersId(Long memberId);
+    List<Team> findDistinctByMembershipsUserIdAndMembershipsStatus(Long memberId, MembershipStatus status);
+
+    Optional<Team> findByIdAndMembershipsUserId(Long teamId, Long memberId);
 }

--- a/src/main/java/com/example/TaskFlow/service/ProjectService.java
+++ b/src/main/java/com/example/TaskFlow/service/ProjectService.java
@@ -1,0 +1,133 @@
+package com.example.TaskFlow.service;
+
+import com.example.TaskFlow.dto.mapper.ProjectMapper;
+import com.example.TaskFlow.dto.request.ProjectRequestDTO;
+import com.example.TaskFlow.dto.response.ProjectResponseDTO;
+import com.example.TaskFlow.model.Project;
+import com.example.TaskFlow.model.Team;
+import com.example.TaskFlow.model.TeamMembership;
+import com.example.TaskFlow.model.User;
+import com.example.TaskFlow.repo.ProjectRepository;
+import com.example.TaskFlow.repo.TeamMembershipRepository;
+import com.example.TaskFlow.repo.TeamRepository;
+import com.example.TaskFlow.repo.UserRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@Transactional
+public class ProjectService {
+
+    private final ProjectRepository projectRepository;
+    private final TeamRepository teamRepository;
+    private final TeamMembershipRepository teamMembershipRepository;
+    private final UserRepository userRepository;
+    private final ProjectMapper projectMapper;
+
+    public ProjectService(ProjectRepository projectRepository,
+                          TeamRepository teamRepository,
+                          TeamMembershipRepository teamMembershipRepository,
+                          UserRepository userRepository,
+                          ProjectMapper projectMapper) {
+        this.projectRepository = projectRepository;
+        this.teamRepository = teamRepository;
+        this.teamMembershipRepository = teamMembershipRepository;
+        this.userRepository = userRepository;
+        this.projectMapper = projectMapper;
+    }
+
+    public List<ProjectResponseDTO> listProjects(Long teamId, String username) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Team not found"));
+        getActiveMembership(teamId, user.getId());
+        return projectRepository.findByTeamId(team.getId()).stream()
+                .map(projectMapper::toResponse)
+                .toList();
+    }
+
+    public ProjectResponseDTO getProject(Long projectId, String username) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Project not found"));
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+        getActiveMembership(project.getTeam().getId(), user.getId());
+        return projectMapper.toResponse(project);
+    }
+
+    public ProjectResponseDTO createProject(ProjectRequestDTO request, String username) {
+        validateDates(request.getStartDate(), request.getDueDate());
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+        Team team = teamRepository.findById(request.getTeamId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Team not found"));
+        TeamMembership membership = getActiveMembership(team.getId(), user.getId());
+        if (!membership.isActiveAdmin()) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Only administrators can manage projects");
+        }
+        String normalizedName = request.getName().trim();
+        if (projectRepository.existsByTeamIdAndNameIgnoreCase(team.getId(), normalizedName)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Project name already exists for team");
+        }
+        Project project = new Project();
+        project.setTeam(team);
+        projectMapper.applyUpsert(request, project);
+        Project saved = projectRepository.save(project);
+        return projectMapper.toResponse(saved);
+    }
+
+    public ProjectResponseDTO updateProject(Long projectId, ProjectRequestDTO request, String username) {
+        validateDates(request.getStartDate(), request.getDueDate());
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Project not found"));
+        if (!project.getTeam().getId().equals(request.getTeamId())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Cannot move project between teams");
+        }
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+        TeamMembership membership = getActiveMembership(project.getTeam().getId(), user.getId());
+        if (!membership.isActiveAdmin()) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Only administrators can manage projects");
+        }
+        String normalizedName = request.getName().trim();
+        if (projectRepository.existsByTeamIdAndNameIgnoreCase(project.getTeam().getId(), normalizedName)
+                && !project.getName().equalsIgnoreCase(normalizedName)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Project name already exists for team");
+        }
+        projectMapper.applyUpsert(request, project);
+        return projectMapper.toResponse(project);
+    }
+
+    public void deleteProject(Long projectId, String username) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Project not found"));
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+        TeamMembership membership = getActiveMembership(project.getTeam().getId(), user.getId());
+        if (!membership.isActiveAdmin()) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Only administrators can manage projects");
+        }
+        projectRepository.delete(project);
+    }
+
+    private TeamMembership getActiveMembership(Long teamId, Long userId) {
+        TeamMembership membership = teamMembershipRepository.findByTeamIdAndUserId(teamId, userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.FORBIDDEN, "Not a member of the team"));
+        if (!membership.getStatus().isActive()) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Membership is not active");
+        }
+        return membership;
+    }
+
+    private void validateDates(LocalDate start, LocalDate due) {
+        if (start != null && due != null && due.isBefore(start)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Due date cannot be before start date");
+        }
+    }
+}

--- a/src/main/java/com/example/TaskFlow/service/ProjectService.java
+++ b/src/main/java/com/example/TaskFlow/service/ProjectService.java
@@ -117,7 +117,7 @@ public class ProjectService {
     }
 
     private TeamMembership getActiveMembership(Long teamId, Long userId) {
-        TeamMembership membership = teamMembershipRepository.findByTeamIdAndUserId(teamId, userId)
+        TeamMembership membership = teamMembershipRepository.findByTeam_IdAndUser_Id(teamId, userId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.FORBIDDEN, "Not a member of the team"));
         if (!membership.getStatus().isActive()) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Membership is not active");

--- a/src/main/java/com/example/TaskFlow/service/TaskService.java
+++ b/src/main/java/com/example/TaskFlow/service/TaskService.java
@@ -1,0 +1,145 @@
+package com.example.TaskFlow.service;
+
+import com.example.TaskFlow.dto.mapper.TaskMapper;
+import com.example.TaskFlow.dto.request.TaskReorderRequestDTO;
+import com.example.TaskFlow.dto.request.TaskRequestDTO;
+import com.example.TaskFlow.dto.response.TaskResponseDTO;
+import com.example.TaskFlow.model.Project;
+import com.example.TaskFlow.model.Task;
+import com.example.TaskFlow.model.User;
+import com.example.TaskFlow.model.enums.TaskStatus;
+import com.example.TaskFlow.repo.ProjectRepository;
+import com.example.TaskFlow.repo.TaskRepository;
+import com.example.TaskFlow.repo.UserRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+public class TaskService {
+
+    private final TaskRepository taskRepository;
+    private final ProjectRepository projectRepository;
+    private final UserRepository userRepository;
+    private final TaskMapper taskMapper;
+
+    public TaskService(TaskRepository taskRepository,
+                       ProjectRepository projectRepository,
+                       UserRepository userRepository,
+                       TaskMapper taskMapper) {
+        this.taskRepository = taskRepository;
+        this.projectRepository = projectRepository;
+        this.userRepository = userRepository;
+        this.taskMapper = taskMapper;
+    }
+
+    @Transactional
+    public TaskResponseDTO createTask(TaskRequestDTO request) {
+        Project project = projectRepository.findById(request.getProjectId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Project not found"));
+        Task task = new Task();
+        task.setProject(project);
+        applyUpsert(request, task);
+        Task saved = taskRepository.save(task);
+        return taskMapper.toResponse(saved);
+    }
+
+    @Transactional
+    public TaskResponseDTO updateTask(Long taskId, TaskRequestDTO request) {
+        Task task = taskRepository.findById(taskId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Task not found"));
+        if (!Objects.equals(task.getProject().getId(), request.getProjectId())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Cannot move task between projects");
+        }
+        applyUpsert(request, task);
+        return taskMapper.toResponse(task);
+    }
+
+    @Transactional
+    public void deleteTask(Long taskId) {
+        Task task = taskRepository.findById(taskId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Task not found"));
+        taskRepository.delete(task);
+    }
+
+    @Transactional
+    public TaskResponseDTO changeStatus(Long taskId, TaskStatus status) {
+        Task task = taskRepository.findById(taskId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Task not found"));
+        if (task.getStatus() == status) {
+            return taskMapper.toResponse(task);
+        }
+        if (!task.getStatus().canTransitionTo(status)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Illegal status transition");
+        }
+        task.setStatus(status);
+        return taskMapper.toResponse(task);
+    }
+
+    @Transactional
+    public List<TaskResponseDTO> reorderTasks(TaskReorderRequestDTO request) {
+        Map<Long, Integer> desiredOrder = request.getPositions().stream()
+                .collect(Collectors.toMap(TaskReorderRequestDTO.PositionDTO::getTaskId, TaskReorderRequestDTO.PositionDTO::getSortOrder));
+        List<Task> tasks = taskRepository.findAllById(desiredOrder.keySet());
+        if (tasks.size() != desiredOrder.size()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "One or more tasks were not found");
+        }
+        for (Task task : tasks) {
+            if (!Objects.equals(task.getProject().getId(), request.getProjectId())) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "All tasks must belong to the same project");
+            }
+            if (task.getStatus() != request.getStatus()) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Tasks must be in the target column to reorder");
+            }
+            task.setSortOrder(desiredOrder.get(task.getId()));
+        }
+        tasks.sort(Comparator.comparing(Task::getSortOrder));
+        taskRepository.saveAll(tasks);
+        return tasks.stream().map(taskMapper::toResponse).toList();
+    }
+
+    @Transactional
+    public List<TaskResponseDTO> getTasks(Long projectId, Optional<TaskStatus> status, Optional<Long> assigneeId) {
+        List<Task> tasks;
+        if (projectId != null) {
+            tasks = taskRepository.findByProjectIdOrderBySortOrderAsc(projectId);
+        } else {
+            tasks = taskRepository.findAll();
+            tasks.sort(Comparator
+                    .comparing((Task task) -> task.getProject() != null ? task.getProject().getId() : Long.MAX_VALUE)
+                    .thenComparing(task -> Optional.ofNullable(task.getSortOrder()).orElse(Integer.MAX_VALUE)));
+        }
+        return tasks.stream()
+                .filter(task -> status.map(task.getStatus()::equals).orElse(true))
+                .filter(task -> assigneeId.map(id -> {
+                    if (task.getAssignment() == null || task.getAssignment().getAssignee() == null) {
+                        return false;
+                    }
+                    return id.equals(task.getAssignment().getAssignee().getId());
+                }).orElse(true))
+                .map(taskMapper::toResponse)
+                .toList();
+    }
+
+    private void applyUpsert(TaskRequestDTO request, Task task) {
+        User assignee = request.getAssigneeId() != null
+                ? userRepository.findById(request.getAssigneeId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Assignee not found"))
+                : null;
+        User delegate = request.getDelegateId() != null
+                ? userRepository.findById(request.getDelegateId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Delegate not found"))
+                : null;
+        taskMapper.applyUpsert(request, task, assignee, delegate);
+        taskMapper.mergeAttachments(task, request.getAttachments(), request.getRemoveAttachmentIds());
+    }
+}

--- a/src/main/java/com/example/TaskFlow/service/TeamService.java
+++ b/src/main/java/com/example/TaskFlow/service/TeamService.java
@@ -1,0 +1,193 @@
+package com.example.TaskFlow.service;
+
+import com.example.TaskFlow.dto.mapper.TeamMapper;
+import com.example.TaskFlow.dto.request.TeamCreateRequestDTO;
+import com.example.TaskFlow.dto.request.TeamInviteRequestDTO;
+import com.example.TaskFlow.dto.request.TeamInvitationResponseDTO;
+import com.example.TaskFlow.dto.request.TeamRoleUpdateRequestDTO;
+import com.example.TaskFlow.dto.response.TeamMembershipResponseDTO;
+import com.example.TaskFlow.dto.response.TeamResponseDTO;
+import com.example.TaskFlow.model.Team;
+import com.example.TaskFlow.model.TeamMembership;
+import com.example.TaskFlow.model.User;
+import com.example.TaskFlow.model.enums.MembershipStatus;
+import com.example.TaskFlow.model.enums.TeamRole;
+import com.example.TaskFlow.repo.TeamMembershipRepository;
+import com.example.TaskFlow.repo.TeamRepository;
+import com.example.TaskFlow.repo.UserRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+
+@Service
+@Transactional
+public class TeamService {
+
+    private final TeamRepository teamRepository;
+    private final TeamMembershipRepository teamMembershipRepository;
+    private final UserRepository userRepository;
+    private final TeamMapper teamMapper;
+
+    public TeamService(TeamRepository teamRepository,
+                       TeamMembershipRepository teamMembershipRepository,
+                       UserRepository userRepository,
+                       TeamMapper teamMapper) {
+        this.teamRepository = teamRepository;
+        this.teamMembershipRepository = teamMembershipRepository;
+        this.userRepository = userRepository;
+        this.teamMapper = teamMapper;
+    }
+
+    public TeamResponseDTO createTeam(TeamCreateRequestDTO request, String creatorUsername) {
+        User creator = userRepository.findByUsername(creatorUsername)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+        if (teamRepository.findByName(request.getName().trim()).isPresent()) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Team name already in use");
+        }
+        Team team = new Team();
+        team.setName(request.getName().trim());
+        team.setDescription(request.getDescription());
+        TeamMembership membership = team.addMembership(creator, TeamRole.ADMIN);
+        membership.setInvitedBy(creator);
+        membership.setInvitedAt(Instant.now());
+        Team persisted = teamRepository.save(team);
+        return teamMapper.toResponse(persisted);
+    }
+
+    @Transactional
+    public List<TeamResponseDTO> getTeamsForUser(String username) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+        return teamRepository.findDistinctByMembershipsUserIdAndMembershipsStatus(user.getId(), MembershipStatus.ACTIVE)
+                .stream()
+                .map(teamMapper::toResponse)
+                .toList();
+    }
+
+    public TeamResponseDTO inviteMember(Long teamId, TeamInviteRequestDTO request, String inviterUsername) {
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Team not found"));
+        User inviter = userRepository.findByUsername(inviterUsername)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+        TeamMembership inviterMembership = teamMembershipRepository.findByTeamIdAndUserId(teamId, inviter.getId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.FORBIDDEN, "Not a member of the team"));
+        if (!inviterMembership.isActiveAdmin()) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Only administrators can invite members");
+        }
+        User invitee = userRepository.findById(request.getUserId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Invitee not found"));
+        TeamMembership existing = teamMembershipRepository.findByTeamIdAndUserId(teamId, invitee.getId()).orElse(null);
+        if (existing != null) {
+            switch (existing.getStatus()) {
+                case ACTIVE -> throw new ResponseStatusException(HttpStatus.CONFLICT, "User already an active member");
+                case INVITED -> {
+                    existing.setRole(request.getRole() != null ? request.getRole() : TeamRole.MEMBER);
+                    existing.setInvitedBy(inviter);
+                    existing.setInvitedAt(Instant.now());
+                    teamMembershipRepository.save(existing);
+                    return teamMapper.toResponse(team);
+                }
+                default -> {
+                    existing.setStatus(MembershipStatus.INVITED);
+                    existing.setRole(request.getRole() != null ? request.getRole() : TeamRole.MEMBER);
+                    existing.setInvitedBy(inviter);
+                    existing.setInvitedAt(Instant.now());
+                    existing.setRespondedAt(null);
+                    existing.setJoinedAt(null);
+                    teamMembershipRepository.save(existing);
+                    return teamMapper.toResponse(team);
+                }
+            }
+        }
+        TeamMembership membership = new TeamMembership();
+        membership.setTeam(team);
+        membership.setUser(invitee);
+        membership.setRole(request.getRole() != null ? request.getRole() : TeamRole.MEMBER);
+        membership.setInvitedBy(inviter);
+        membership.setStatus(MembershipStatus.INVITED);
+        membership.setInvitedAt(Instant.now());
+        team.getMemberships().add(membership);
+        invitee.getMemberships().add(membership);
+        teamRepository.save(team);
+        return teamMapper.toResponse(team);
+    }
+
+    public TeamMembershipResponseDTO respondToInvitation(Long membershipId, TeamInvitationResponseDTO response, String username) {
+        TeamMembership membership = teamMembershipRepository.findById(membershipId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Invitation not found"));
+        if (!Objects.equals(membership.getUser() != null ? membership.getUser().getUsername() : null, username)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Cannot respond to invitations for other users");
+        }
+        if (membership.getStatus() != MembershipStatus.INVITED) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invitation already processed");
+        }
+        if (Boolean.TRUE.equals(response.accept())) {
+            membership.activate();
+        } else {
+            membership.decline();
+        }
+        teamMembershipRepository.save(membership);
+        return TeamMembershipResponseDTO.builder()
+                .id(membership.getId())
+                .userId(membership.getUser() != null ? membership.getUser().getId() : null)
+                .username(membership.getUser() != null ? membership.getUser().getUsername() : null)
+                .role(membership.getRole())
+                .status(membership.getStatus())
+                .invitedAt(membership.getInvitedAt())
+                .joinedAt(membership.getJoinedAt())
+                .respondedAt(membership.getRespondedAt())
+                .build();
+    }
+
+    public TeamResponseDTO updateMemberRole(Long teamId, Long memberId, TeamRoleUpdateRequestDTO request, String actorUsername) {
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Team not found"));
+        User actor = userRepository.findByUsername(actorUsername)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+        TeamMembership actorMembership = teamMembershipRepository.findByTeamIdAndUserId(teamId, actor.getId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.FORBIDDEN, "Not a team member"));
+        if (!actorMembership.isActiveAdmin()) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Only administrators can update roles");
+        }
+        TeamMembership target = teamMembershipRepository.findByTeamIdAndUserId(teamId, memberId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Membership not found"));
+        if (!target.getStatus().isActive()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Membership is not active");
+        }
+        target.setRole(request.role());
+        teamMembershipRepository.save(target);
+        return teamMapper.toResponse(team);
+    }
+
+    public void removeMember(Long teamId, Long memberId, String actorUsername) {
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Team not found"));
+        User actor = userRepository.findByUsername(actorUsername)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+        TeamMembership actorMembership = teamMembershipRepository.findByTeamIdAndUserId(teamId, actor.getId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.FORBIDDEN, "Not a team member"));
+        if (!actorMembership.isActiveAdmin() && !Objects.equals(memberId, actor.getId())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Insufficient permissions to remove members");
+        }
+        TeamMembership target = teamMembershipRepository.findByTeamIdAndUserId(teamId, memberId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Membership not found"));
+        if (!target.getStatus().isActive()) {
+            target.setStatus(MembershipStatus.REMOVED);
+            teamMembershipRepository.save(target);
+            return;
+        }
+        long adminCount = team.getMemberships().stream().filter(TeamMembership::isActiveAdmin).count();
+        if (target.isActiveAdmin() && adminCount <= 1) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Cannot remove the last administrator");
+        }
+        target.setStatus(MembershipStatus.REMOVED);
+        target.setRespondedAt(Instant.now());
+        target.setJoinedAt(null);
+        teamMembershipRepository.save(target);
+    }
+}

--- a/src/test/java/com/example/TaskFlow/controller/ProjectControllerTest.java
+++ b/src/test/java/com/example/TaskFlow/controller/ProjectControllerTest.java
@@ -1,0 +1,118 @@
+package com.example.TaskFlow.controller;
+
+import com.example.TaskFlow.config.SecurityConfig;
+import com.example.TaskFlow.dto.request.ProjectRequestDTO;
+import com.example.TaskFlow.dto.response.ProjectResponseDTO;
+import com.example.TaskFlow.jwt.JwtAuthFilter;
+import com.example.TaskFlow.service.ProjectService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = ProjectController.class)
+@Import(SecurityConfig.class)
+class ProjectControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private ProjectService projectService;
+
+    @MockBean
+    private JwtAuthFilter jwtAuthFilter;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        Mockito.doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            ((jakarta.servlet.FilterChain) args[2]).doFilter(args[0], args[1]);
+            return null;
+        }).when(jwtAuthFilter).doFilter(Mockito.any(), Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    void listProjectsRequiresAuthentication() throws Exception {
+        mockMvc.perform(get("/api/projects").param("teamId", "5"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "MEMBER")
+    void listProjectsReturnsTeamProjects() throws Exception {
+        ProjectResponseDTO response = ProjectResponseDTO.builder()
+                .id(1L)
+                .teamId(7L)
+                .name("Alpha")
+                .build();
+        given(projectService.listProjects(7L, "user")).willReturn(List.of(response));
+
+        mockMvc.perform(get("/api/projects").param("teamId", "7"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(1L))
+                .andExpect(jsonPath("$[0].name").value("Alpha"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void createProjectReturnsCreatedProject() throws Exception {
+        ProjectResponseDTO response = ProjectResponseDTO.builder()
+                .id(20L)
+                .teamId(5L)
+                .name("New Project")
+                .description("Build integrations")
+                .startDate(LocalDate.now())
+                .dueDate(LocalDate.now().plusDays(3))
+                .createdAt(Instant.now())
+                .updatedAt(Instant.now())
+                .build();
+        given(projectService.createProject(any(ProjectRequestDTO.class), eq("user"))).willReturn(response);
+
+        ProjectRequestDTO request = new ProjectRequestDTO();
+        request.setTeamId(5L);
+        request.setName("New Project");
+        request.setDescription("Build integrations");
+        request.setStartDate(LocalDate.now());
+        request.setDueDate(LocalDate.now().plusDays(3));
+
+        mockMvc.perform(post("/api/projects")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(20L))
+                .andExpect(jsonPath("$.name").value("New Project"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void deleteProjectReturnsNoContent() throws Exception {
+        Mockito.doNothing().when(projectService).deleteProject(9L, "user");
+
+        mockMvc.perform(delete("/api/projects/9"))
+                .andExpect(status().isNoContent());
+    }
+}

--- a/src/test/java/com/example/TaskFlow/controller/TaskControllerTest.java
+++ b/src/test/java/com/example/TaskFlow/controller/TaskControllerTest.java
@@ -1,0 +1,115 @@
+package com.example.TaskFlow.controller;
+
+import com.example.TaskFlow.config.SecurityConfig;
+import com.example.TaskFlow.dto.request.TaskRequestDTO;
+import com.example.TaskFlow.dto.request.TaskStatusUpdateRequestDTO;
+import com.example.TaskFlow.dto.response.TaskAssignmentDTO;
+import com.example.TaskFlow.dto.response.TaskResponseDTO;
+import com.example.TaskFlow.jwt.JwtAuthFilter;
+import com.example.TaskFlow.model.enums.TaskPriority;
+import com.example.TaskFlow.model.enums.TaskStatus;
+import com.example.TaskFlow.service.TaskService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = TaskController.class)
+@Import(SecurityConfig.class)
+class TaskControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private TaskService taskService;
+
+    @MockBean
+    private JwtAuthFilter jwtAuthFilter;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        Mockito.doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            ((jakarta.servlet.FilterChain) args[2]).doFilter(args[0], args[1]);
+            return null;
+        }).when(jwtAuthFilter).doFilter(Mockito.any(), Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    void listTasksRequiresAuthentication() throws Exception {
+        mockMvc.perform(get("/api/tasks"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "MEMBER")
+    void createTaskReturnsCreatedTask() throws Exception {
+        TaskResponseDTO response = TaskResponseDTO.builder()
+                .id(100L)
+                .title("Plan sprint")
+                .status(TaskStatus.TODO)
+                .priority(TaskPriority.MEDIUM)
+                .assignment(new TaskAssignmentDTO(1L, null, Instant.now(), null, null))
+                .attachments(List.of())
+                .comments(List.of())
+                .build();
+        given(taskService.createTask(any(TaskRequestDTO.class))).willReturn(response);
+
+        TaskRequestDTO request = new TaskRequestDTO();
+        request.setProjectId(9L);
+        request.setTitle("Plan sprint");
+        request.setStatus(TaskStatus.TODO);
+        request.setPriority(TaskPriority.MEDIUM);
+        request.setDueDate(LocalDate.now().plusDays(2));
+
+        mockMvc.perform(post("/api/tasks")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(100L))
+                .andExpect(jsonPath("$.title").value("Plan sprint"));
+    }
+
+    @Test
+    @WithMockUser(roles = "MEMBER")
+    void updateStatusDelegatesToService() throws Exception {
+        TaskResponseDTO response = TaskResponseDTO.builder()
+                .id(5L)
+                .status(TaskStatus.IN_PROGRESS)
+                .priority(TaskPriority.HIGH)
+                .assignment(new TaskAssignmentDTO(1L, null, Instant.now(), null, null))
+                .attachments(List.of())
+                .comments(List.of())
+                .build();
+        given(taskService.changeStatus(eq(5L), eq(TaskStatus.IN_PROGRESS))).willReturn(response);
+
+        mockMvc.perform(patch("/api/tasks/5/status")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new TaskStatusUpdateRequestDTO(TaskStatus.IN_PROGRESS))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("IN_PROGRESS"));
+    }
+}

--- a/src/test/java/com/example/TaskFlow/controller/TeamControllerTest.java
+++ b/src/test/java/com/example/TaskFlow/controller/TeamControllerTest.java
@@ -1,0 +1,119 @@
+package com.example.TaskFlow.controller;
+
+import com.example.TaskFlow.config.SecurityConfig;
+import com.example.TaskFlow.dto.request.TeamCreateRequestDTO;
+import com.example.TaskFlow.dto.request.TeamInviteRequestDTO;
+import com.example.TaskFlow.dto.response.TeamMembershipResponseDTO;
+import com.example.TaskFlow.dto.response.TeamResponseDTO;
+import com.example.TaskFlow.jwt.JwtAuthFilter;
+import com.example.TaskFlow.model.enums.MembershipStatus;
+import com.example.TaskFlow.model.enums.TeamRole;
+import com.example.TaskFlow.service.TeamService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = TeamController.class)
+@Import(SecurityConfig.class)
+class TeamControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private TeamService teamService;
+
+    @MockBean
+    private JwtAuthFilter jwtAuthFilter;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        Mockito.doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            ((jakarta.servlet.FilterChain) args[2]).doFilter(args[0], args[1]);
+            return null;
+        }).when(jwtAuthFilter).doFilter(Mockito.any(), Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    void routesRequireAuthentication() throws Exception {
+        mockMvc.perform(get("/api/teams"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "user", roles = "MEMBER")
+    void createTeamReturnsCreated() throws Exception {
+        TeamResponseDTO response = TeamResponseDTO.builder()
+                .id(22L)
+                .name("Core")
+                .member(TeamMembershipResponseDTO.builder()
+                        .id(5L)
+                        .userId(1L)
+                        .username("owner")
+                        .role(TeamRole.ADMIN)
+                        .status(MembershipStatus.ACTIVE)
+                        .invitedAt(Instant.now())
+                        .joinedAt(Instant.now())
+                        .build())
+                .build();
+        given(teamService.createTeam(any(TeamCreateRequestDTO.class), eq("user"))).willReturn(response);
+
+        TeamCreateRequestDTO request = new TeamCreateRequestDTO();
+        request.setName("Core");
+
+        mockMvc.perform(post("/api/teams")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("Core"))
+                .andExpect(jsonPath("$.members[0].role").value("ADMIN"));
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void inviteMemberReturnsUpdatedTeam() throws Exception {
+        TeamResponseDTO response = TeamResponseDTO.builder()
+                .id(30L)
+                .name("Platform")
+                .member(TeamMembershipResponseDTO.builder()
+                        .id(11L)
+                        .userId(5L)
+                        .username("invitee")
+                        .role(TeamRole.MEMBER)
+                        .status(MembershipStatus.INVITED)
+                        .invitedAt(Instant.now())
+                        .build())
+                .build();
+        given(teamService.inviteMember(eq(30L), any(TeamInviteRequestDTO.class), eq("admin"))).willReturn(response);
+
+        TeamInviteRequestDTO request = new TeamInviteRequestDTO();
+        request.setUserId(5L);
+
+        mockMvc.perform(post("/api/teams/30/invite")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.members[0].status").value("INVITED"));
+    }
+}

--- a/src/test/java/com/example/TaskFlow/repo/TeamProjectTaskRepositoryTests.java
+++ b/src/test/java/com/example/TaskFlow/repo/TeamProjectTaskRepositoryTests.java
@@ -5,7 +5,9 @@ import com.example.TaskFlow.model.Comment;
 import com.example.TaskFlow.model.Project;
 import com.example.TaskFlow.model.Task;
 import com.example.TaskFlow.model.Team;
+import com.example.TaskFlow.model.enums.TeamRole;
 import com.example.TaskFlow.model.User;
+import com.example.TaskFlow.model.enums.MembershipStatus;
 import com.example.TaskFlow.model.enums.TaskPriority;
 import com.example.TaskFlow.model.enums.TaskStatus;
 import org.junit.jupiter.api.Test;
@@ -46,7 +48,7 @@ class TeamProjectTaskRepositoryTests {
         Team team = new Team();
         team.setName("Platform");
         team.setDescription("Core platform initiatives");
-        team.addMember(owner);
+        team.addMembership(owner, TeamRole.ADMIN);
         team = teamRepository.saveAndFlush(team);
 
         Project project = new Project();
@@ -107,8 +109,8 @@ class TeamProjectTaskRepositoryTests {
 
         Team team = new Team();
         team.setName("Mobile");
-        team.addMember(primary);
-        team.addMember(collaborator);
+        team.addMembership(primary, TeamRole.ADMIN);
+        team.addMembership(collaborator, TeamRole.MEMBER);
         team = teamRepository.saveAndFlush(team);
 
         Project project = new Project();
@@ -127,7 +129,7 @@ class TeamProjectTaskRepositoryTests {
 
         projectRepository.saveAndFlush(project);
 
-        assertThat(teamRepository.findByMembersId(primary.getId()))
+        assertThat(teamRepository.findDistinctByMembershipsUserIdAndMembershipsStatus(primary.getId(), MembershipStatus.ACTIVE))
                 .extracting(Team::getId)
                 .contains(team.getId());
 

--- a/src/test/java/com/example/TaskFlow/service/ProjectServiceTest.java
+++ b/src/test/java/com/example/TaskFlow/service/ProjectServiceTest.java
@@ -1,0 +1,154 @@
+package com.example.TaskFlow.service;
+
+import com.example.TaskFlow.dto.mapper.ProjectMapper;
+import com.example.TaskFlow.dto.mapper.TaskMapper;
+import com.example.TaskFlow.dto.request.ProjectRequestDTO;
+import com.example.TaskFlow.dto.response.ProjectResponseDTO;
+import com.example.TaskFlow.model.Project;
+import com.example.TaskFlow.model.Team;
+import com.example.TaskFlow.model.TeamMembership;
+import com.example.TaskFlow.model.User;
+import com.example.TaskFlow.model.enums.MembershipStatus;
+import com.example.TaskFlow.model.enums.TeamRole;
+import com.example.TaskFlow.repo.ProjectRepository;
+import com.example.TaskFlow.repo.TeamMembershipRepository;
+import com.example.TaskFlow.repo.TeamRepository;
+import com.example.TaskFlow.repo.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectServiceTest {
+
+    @Mock
+    private ProjectRepository projectRepository;
+    @Mock
+    private TeamRepository teamRepository;
+    @Mock
+    private TeamMembershipRepository teamMembershipRepository;
+    @Mock
+    private UserRepository userRepository;
+
+    private ProjectService projectService;
+
+    @BeforeEach
+    void setUp() {
+        projectService = new ProjectService(projectRepository, teamRepository, teamMembershipRepository, userRepository, new ProjectMapper(new TaskMapper()));
+    }
+
+    @Test
+    void createProjectShouldPersistWhenAdmin() {
+        User user = new User();
+        user.setId(1L);
+        user.setUsername("admin");
+        Team team = new Team();
+        team.setId(2L);
+        TeamMembership membership = new TeamMembership();
+        membership.setTeam(team);
+        membership.setUser(user);
+        membership.setRole(TeamRole.ADMIN);
+        membership.setStatus(MembershipStatus.ACTIVE);
+
+        ProjectRequestDTO request = new ProjectRequestDTO();
+        request.setTeamId(2L);
+        request.setName("Launch Pad");
+        request.setStartDate(LocalDate.now());
+        request.setDueDate(LocalDate.now().plusDays(7));
+
+        when(userRepository.findByUsername("admin")).thenReturn(Optional.of(user));
+        when(teamRepository.findById(2L)).thenReturn(Optional.of(team));
+        when(teamMembershipRepository.findByTeamIdAndUserId(2L, 1L)).thenReturn(Optional.of(membership));
+        when(projectRepository.existsByTeamIdAndNameIgnoreCase(2L, "Launch Pad")).thenReturn(false);
+        when(projectRepository.save(any(Project.class))).thenAnswer(invocation -> {
+            Project project = invocation.getArgument(0);
+            project.setId(10L);
+            return project;
+        });
+
+        ProjectResponseDTO response = projectService.createProject(request, "admin");
+
+        assertThat(response.getId()).isEqualTo(10L);
+        assertThat(response.getTeamId()).isEqualTo(2L);
+        assertThat(response.getName()).isEqualTo("Launch Pad");
+    }
+
+    @Test
+    void createProjectShouldRejectNonAdmin() {
+        User user = new User();
+        user.setId(1L);
+        user.setUsername("member");
+        Team team = new Team();
+        team.setId(2L);
+        TeamMembership membership = new TeamMembership();
+        membership.setTeam(team);
+        membership.setUser(user);
+        membership.setRole(TeamRole.MEMBER);
+        membership.setStatus(MembershipStatus.ACTIVE);
+
+        ProjectRequestDTO request = new ProjectRequestDTO();
+        request.setTeamId(2L);
+        request.setName("Iteration Zero");
+
+        when(userRepository.findByUsername("member")).thenReturn(Optional.of(user));
+        when(teamRepository.findById(2L)).thenReturn(Optional.of(team));
+        when(teamMembershipRepository.findByTeamIdAndUserId(2L, 1L)).thenReturn(Optional.of(membership));
+
+        assertThatThrownBy(() -> projectService.createProject(request, "member"))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("Only administrators can manage projects");
+    }
+
+    @Test
+    void updateProjectShouldValidateTeamConsistency() {
+        Project project = new Project();
+        Team team = new Team();
+        team.setId(3L);
+        project.setTeam(team);
+
+        ProjectRequestDTO request = new ProjectRequestDTO();
+        request.setTeamId(4L);
+        request.setName("Mismatch");
+
+        when(projectRepository.findById(5L)).thenReturn(Optional.of(project));
+
+        assertThatThrownBy(() -> projectService.updateProject(5L, request, "admin"))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("Cannot move project between teams");
+    }
+
+    @Test
+    void deleteProjectShouldRequireAdministrator() {
+        Project project = new Project();
+        Team team = new Team();
+        team.setId(8L);
+        project.setTeam(team);
+        User user = new User();
+        user.setId(9L);
+        user.setUsername("member");
+        TeamMembership membership = new TeamMembership();
+        membership.setTeam(team);
+        membership.setUser(user);
+        membership.setRole(TeamRole.MEMBER);
+        membership.setStatus(MembershipStatus.ACTIVE);
+
+        when(projectRepository.findById(12L)).thenReturn(Optional.of(project));
+        when(userRepository.findByUsername("member")).thenReturn(Optional.of(user));
+        when(teamMembershipRepository.findByTeamIdAndUserId(8L, 9L)).thenReturn(Optional.of(membership));
+
+        assertThatThrownBy(() -> projectService.deleteProject(12L, "member"))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("Only administrators can manage projects");
+    }
+}

--- a/src/test/java/com/example/TaskFlow/service/ProjectServiceTest.java
+++ b/src/test/java/com/example/TaskFlow/service/ProjectServiceTest.java
@@ -69,7 +69,7 @@ class ProjectServiceTest {
 
         when(userRepository.findByUsername("admin")).thenReturn(Optional.of(user));
         when(teamRepository.findById(2L)).thenReturn(Optional.of(team));
-        when(teamMembershipRepository.findByTeamIdAndUserId(2L, 1L)).thenReturn(Optional.of(membership));
+        when(teamMembershipRepository.findByTeam_IdAndUser_Id(2L, 1L)).thenReturn(Optional.of(membership));
         when(projectRepository.existsByTeamIdAndNameIgnoreCase(2L, "Launch Pad")).thenReturn(false);
         when(projectRepository.save(any(Project.class))).thenAnswer(invocation -> {
             Project project = invocation.getArgument(0);
@@ -103,7 +103,7 @@ class ProjectServiceTest {
 
         when(userRepository.findByUsername("member")).thenReturn(Optional.of(user));
         when(teamRepository.findById(2L)).thenReturn(Optional.of(team));
-        when(teamMembershipRepository.findByTeamIdAndUserId(2L, 1L)).thenReturn(Optional.of(membership));
+        when(teamMembershipRepository.findByTeam_IdAndUser_Id(2L, 1L)).thenReturn(Optional.of(membership));
 
         assertThatThrownBy(() -> projectService.createProject(request, "member"))
                 .isInstanceOf(ResponseStatusException.class)
@@ -145,7 +145,7 @@ class ProjectServiceTest {
 
         when(projectRepository.findById(12L)).thenReturn(Optional.of(project));
         when(userRepository.findByUsername("member")).thenReturn(Optional.of(user));
-        when(teamMembershipRepository.findByTeamIdAndUserId(8L, 9L)).thenReturn(Optional.of(membership));
+        when(teamMembershipRepository.findByTeam_IdAndUser_Id(8L, 9L)).thenReturn(Optional.of(membership));
 
         assertThatThrownBy(() -> projectService.deleteProject(12L, "member"))
                 .isInstanceOf(ResponseStatusException.class)

--- a/src/test/java/com/example/TaskFlow/service/TaskServiceTest.java
+++ b/src/test/java/com/example/TaskFlow/service/TaskServiceTest.java
@@ -1,0 +1,141 @@
+package com.example.TaskFlow.service;
+
+import com.example.TaskFlow.dto.mapper.TaskMapper;
+import com.example.TaskFlow.dto.request.AttachmentPayloadDTO;
+import com.example.TaskFlow.dto.request.TaskReorderRequestDTO;
+import com.example.TaskFlow.dto.request.TaskRequestDTO;
+import com.example.TaskFlow.dto.response.TaskResponseDTO;
+import com.example.TaskFlow.model.Project;
+import com.example.TaskFlow.model.Task;
+import com.example.TaskFlow.model.User;
+import com.example.TaskFlow.model.enums.TaskPriority;
+import com.example.TaskFlow.model.enums.TaskStatus;
+import com.example.TaskFlow.repo.ProjectRepository;
+import com.example.TaskFlow.repo.TaskRepository;
+import com.example.TaskFlow.repo.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TaskServiceTest {
+
+    @Mock
+    private TaskRepository taskRepository;
+    @Mock
+    private ProjectRepository projectRepository;
+    @Mock
+    private UserRepository userRepository;
+
+    private TaskService taskService;
+
+    @BeforeEach
+    void setUp() {
+        taskService = new TaskService(taskRepository, projectRepository, userRepository, new TaskMapper());
+    }
+
+    @Test
+    void createTaskShouldPersistAttachmentsAndAssignment() {
+        TaskRequestDTO request = buildRequest();
+        Project project = new Project();
+        project.setId(1L);
+        when(projectRepository.findById(1L)).thenReturn(Optional.of(project));
+        User assignee = new User();
+        assignee.setId(3L);
+        assignee.setUsername("assignee");
+        when(userRepository.findById(3L)).thenReturn(Optional.of(assignee));
+        when(taskRepository.save(any(Task.class))).thenAnswer(invocation -> {
+            Task task = invocation.getArgument(0);
+            task.setId(10L);
+            task.getAttachments().forEach(att -> {
+                att.setId((long) (task.getAttachments().indexOf(att) + 1));
+                att.setTask(task);
+            });
+            return task;
+        });
+
+        TaskResponseDTO response = taskService.createTask(request);
+
+        assertThat(response.getId()).isEqualTo(10L);
+        assertThat(response.getAssignment().assigneeId()).isEqualTo(3L);
+        assertThat(response.getAttachments()).hasSize(1);
+        assertThat(response.getAttachments().get(0).getFileName()).isEqualTo("design.pdf");
+    }
+
+    @Test
+    void changeStatusShouldValidateTransitions() {
+        Task task = new Task();
+        task.setId(5L);
+        task.setStatus(TaskStatus.TODO);
+        when(taskRepository.findById(5L)).thenReturn(Optional.of(task));
+
+        TaskResponseDTO response = taskService.changeStatus(5L, TaskStatus.IN_PROGRESS);
+        assertThat(response.getStatus()).isEqualTo(TaskStatus.IN_PROGRESS);
+
+        when(taskRepository.findById(5L)).thenReturn(Optional.of(task));
+        assertThatThrownBy(() -> taskService.changeStatus(5L, TaskStatus.BACKLOG))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("Illegal status transition");
+    }
+
+    @Test
+    void reorderTasksShouldApplyNewOrder() {
+        TaskReorderRequestDTO request = new TaskReorderRequestDTO();
+        request.setProjectId(7L);
+        request.setStatus(TaskStatus.TODO);
+        TaskReorderRequestDTO.PositionDTO first = new TaskReorderRequestDTO.PositionDTO();
+        first.setTaskId(1L);
+        first.setSortOrder(2);
+        TaskReorderRequestDTO.PositionDTO second = new TaskReorderRequestDTO.PositionDTO();
+        second.setTaskId(2L);
+        second.setSortOrder(1);
+        request.setPositions(List.of(first, second));
+
+        Task taskA = new Task();
+        taskA.setId(1L);
+        taskA.setStatus(TaskStatus.TODO);
+        Project project = new Project();
+        project.setId(7L);
+        taskA.setProject(project);
+        Task taskB = new Task();
+        taskB.setId(2L);
+        taskB.setStatus(TaskStatus.TODO);
+        taskB.setProject(project);
+        when(taskRepository.findAllById(Mockito.<Iterable<Long>>any())).thenReturn(List.of(taskA, taskB));
+
+        List<TaskResponseDTO> responses = taskService.reorderTasks(request);
+        assertThat(responses).extracting(TaskResponseDTO::getId).containsExactly(2L, 1L);
+    }
+
+    private TaskRequestDTO buildRequest() {
+        TaskRequestDTO request = new TaskRequestDTO();
+        request.setProjectId(1L);
+        request.setTitle("Create mocks");
+        request.setDescription("Write documentation");
+        request.setPriority(TaskPriority.HIGH);
+        request.setAssigneeId(3L);
+        request.setDueDate(LocalDate.now().plusDays(5));
+        request.setAssignedAt(Instant.now());
+        AttachmentPayloadDTO attachment = new AttachmentPayloadDTO();
+        attachment.setFileName("design.pdf");
+        attachment.setStorageUrl("https://files/design.pdf");
+        attachment.setContentType("application/pdf");
+        attachment.setFileSize(1024L);
+        request.setAttachments(List.of(attachment));
+        return request;
+    }
+}

--- a/src/test/java/com/example/TaskFlow/service/TeamServiceTest.java
+++ b/src/test/java/com/example/TaskFlow/service/TeamServiceTest.java
@@ -20,7 +20,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -78,7 +77,7 @@ class TeamServiceTest {
         adminMembership.setStatus(MembershipStatus.ACTIVE);
         when(teamRepository.findById(4L)).thenReturn(Optional.of(team));
         when(userRepository.findByUsername("admin")).thenReturn(Optional.of(admin));
-        when(membershipRepository.findByTeamIdAndUserId(4L, 1L)).thenReturn(Optional.of(adminMembership));
+        when(membershipRepository.findByTeam_IdAndUser_Id(4L, 1L)).thenReturn(Optional.of(adminMembership));
         User invitee = new User();
         invitee.setId(8L);
         invitee.setUsername("member");
@@ -115,8 +114,8 @@ class TeamServiceTest {
         memberMembership.setRole(TeamRole.MEMBER);
         when(teamRepository.findById(2L)).thenReturn(Optional.of(team));
         when(userRepository.findByUsername("admin")).thenReturn(Optional.of(admin));
-        when(membershipRepository.findByTeamIdAndUserId(2L, 1L)).thenReturn(Optional.of(adminMembership));
-        when(membershipRepository.findByTeamIdAndUserId(2L, 7L)).thenReturn(Optional.of(memberMembership));
+        when(membershipRepository.findByTeam_IdAndUser_Id(2L, 1L)).thenReturn(Optional.of(adminMembership));
+        when(membershipRepository.findByTeam_IdAndUser_Id(2L, 7L)).thenReturn(Optional.of(memberMembership));
 
         TeamRoleUpdateRequestDTO request = new TeamRoleUpdateRequestDTO(TeamRole.ADMIN);
         teamService.updateMemberRole(2L, 7L, request, "admin");
@@ -139,8 +138,8 @@ class TeamServiceTest {
         team.getMemberships().add(adminMembership);
         when(teamRepository.findById(10L)).thenReturn(Optional.of(team));
         when(userRepository.findByUsername("admin")).thenReturn(Optional.of(admin));
-        when(membershipRepository.findByTeamIdAndUserId(10L, 3L)).thenReturn(Optional.of(adminMembership));
-        when(membershipRepository.findByTeamIdAndUserId(10L, 3L)).thenReturn(Optional.of(adminMembership));
+        when(membershipRepository.findByTeam_IdAndUser_Id(10L, 3L)).thenReturn(Optional.of(adminMembership));
+        when(membershipRepository.findByTeam_IdAndUser_Id(10L, 3L)).thenReturn(Optional.of(adminMembership));
 
         assertThatThrownBy(() -> teamService.removeMember(10L, 3L, "admin"))
                 .isInstanceOf(ResponseStatusException.class)

--- a/src/test/java/com/example/TaskFlow/service/TeamServiceTest.java
+++ b/src/test/java/com/example/TaskFlow/service/TeamServiceTest.java
@@ -1,0 +1,149 @@
+package com.example.TaskFlow.service;
+
+import com.example.TaskFlow.dto.mapper.TeamMapper;
+import com.example.TaskFlow.dto.request.TeamCreateRequestDTO;
+import com.example.TaskFlow.dto.request.TeamInviteRequestDTO;
+import com.example.TaskFlow.dto.request.TeamRoleUpdateRequestDTO;
+import com.example.TaskFlow.dto.response.TeamResponseDTO;
+import com.example.TaskFlow.model.Team;
+import com.example.TaskFlow.model.TeamMembership;
+import com.example.TaskFlow.model.User;
+import com.example.TaskFlow.model.enums.MembershipStatus;
+import com.example.TaskFlow.model.enums.TeamRole;
+import com.example.TaskFlow.repo.TeamMembershipRepository;
+import com.example.TaskFlow.repo.TeamRepository;
+import com.example.TaskFlow.repo.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TeamServiceTest {
+
+    @Mock
+    private TeamRepository teamRepository;
+    @Mock
+    private TeamMembershipRepository membershipRepository;
+    @Mock
+    private UserRepository userRepository;
+
+    private TeamService teamService;
+
+    @BeforeEach
+    void setUp() {
+        teamService = new TeamService(teamRepository, membershipRepository, userRepository, new TeamMapper());
+    }
+
+    @Test
+    void createTeamAssignsCreatorAsAdmin() {
+        User creator = new User();
+        creator.setId(5L);
+        creator.setUsername("creator");
+        when(userRepository.findByUsername("creator")).thenReturn(Optional.of(creator));
+        when(teamRepository.findByName("Platform")).thenReturn(Optional.empty());
+        when(teamRepository.save(any(Team.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        TeamCreateRequestDTO request = new TeamCreateRequestDTO();
+        request.setName("Platform");
+        request.setDescription("Platform engineering");
+
+        TeamResponseDTO response = teamService.createTeam(request, "creator");
+
+        assertThat(response.getName()).isEqualTo("Platform");
+        assertThat(response.getMembers()).anyMatch(member -> member.getUserId().equals(5L) && member.getRole() == TeamRole.ADMIN);
+    }
+
+    @Test
+    void inviteMemberRequiresAdminRole() {
+        Team team = new Team();
+        team.setId(4L);
+        User admin = new User();
+        admin.setId(1L);
+        admin.setUsername("admin");
+        TeamMembership adminMembership = new TeamMembership();
+        adminMembership.setTeam(team);
+        adminMembership.setUser(admin);
+        adminMembership.setRole(TeamRole.ADMIN);
+        adminMembership.setStatus(MembershipStatus.ACTIVE);
+        when(teamRepository.findById(4L)).thenReturn(Optional.of(team));
+        when(userRepository.findByUsername("admin")).thenReturn(Optional.of(admin));
+        when(membershipRepository.findByTeamIdAndUserId(4L, 1L)).thenReturn(Optional.of(adminMembership));
+        User invitee = new User();
+        invitee.setId(8L);
+        invitee.setUsername("member");
+        when(userRepository.findById(8L)).thenReturn(Optional.of(invitee));
+        when(teamRepository.save(any(Team.class))).thenReturn(team);
+
+        TeamInviteRequestDTO request = new TeamInviteRequestDTO();
+        request.setUserId(8L);
+        request.setRole(TeamRole.MEMBER);
+
+        TeamResponseDTO response = teamService.inviteMember(4L, request, "admin");
+        assertThat(response.getMembers()).anyMatch(member -> member.getUserId().equals(8L) && member.getStatus() == MembershipStatus.INVITED);
+    }
+
+    @Test
+    void updateRoleValidatesActiveMembership() {
+        Team team = new Team();
+        team.setId(2L);
+        User admin = new User();
+        admin.setId(1L);
+        admin.setUsername("admin");
+        TeamMembership adminMembership = new TeamMembership();
+        adminMembership.setTeam(team);
+        adminMembership.setUser(admin);
+        adminMembership.setRole(TeamRole.ADMIN);
+        adminMembership.setStatus(MembershipStatus.ACTIVE);
+        User member = new User();
+        member.setId(7L);
+        member.setUsername("member");
+        TeamMembership memberMembership = new TeamMembership();
+        memberMembership.setTeam(team);
+        memberMembership.setUser(member);
+        memberMembership.setStatus(MembershipStatus.ACTIVE);
+        memberMembership.setRole(TeamRole.MEMBER);
+        when(teamRepository.findById(2L)).thenReturn(Optional.of(team));
+        when(userRepository.findByUsername("admin")).thenReturn(Optional.of(admin));
+        when(membershipRepository.findByTeamIdAndUserId(2L, 1L)).thenReturn(Optional.of(adminMembership));
+        when(membershipRepository.findByTeamIdAndUserId(2L, 7L)).thenReturn(Optional.of(memberMembership));
+
+        TeamRoleUpdateRequestDTO request = new TeamRoleUpdateRequestDTO(TeamRole.ADMIN);
+        teamService.updateMemberRole(2L, 7L, request, "admin");
+
+        assertThat(memberMembership.getRole()).isEqualTo(TeamRole.ADMIN);
+    }
+
+    @Test
+    void removeMemberPreventsRemovingLastAdmin() {
+        Team team = new Team();
+        team.setId(10L);
+        User admin = new User();
+        admin.setId(3L);
+        admin.setUsername("admin");
+        TeamMembership adminMembership = new TeamMembership();
+        adminMembership.setTeam(team);
+        adminMembership.setUser(admin);
+        adminMembership.setRole(TeamRole.ADMIN);
+        adminMembership.setStatus(MembershipStatus.ACTIVE);
+        team.getMemberships().add(adminMembership);
+        when(teamRepository.findById(10L)).thenReturn(Optional.of(team));
+        when(userRepository.findByUsername("admin")).thenReturn(Optional.of(admin));
+        when(membershipRepository.findByTeamIdAndUserId(10L, 3L)).thenReturn(Optional.of(adminMembership));
+        when(membershipRepository.findByTeamIdAndUserId(10L, 3L)).thenReturn(Optional.of(adminMembership));
+
+        assertThatThrownBy(() -> teamService.removeMember(10L, 3L, "admin"))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("Cannot remove the last administrator");
+    }
+}


### PR DESCRIPTION
## Summary
- add TaskService, DTO mappers, and a secured TaskController for CRUD operations, status transitions, and column reordering
- introduce TeamMembership-based RBAC with TeamService/Controller, invitation flows, and updated authentication role claims
- expand persistence and DTO layers with membership enums, repositories, and tests covering new services and controllers

## Testing
- `./mvnw test` *(fails: unable to resolve parent POM because Maven Central is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4510230e0832a800a9325c0687a1c